### PR TITLE
account for multiple invoices on the same day

### DIFF
--- a/invoice_print_report_balance_payment/account_invoice.py
+++ b/invoice_print_report_balance_payment/account_invoice.py
@@ -74,8 +74,18 @@ class account_invoice(orm.Model):
     def _payment_total_get(self, cr, uid, ids, field_names, arg, context=None):
         res = {}
         for invoice in self.browse(cr, uid, ids, context=context):
-            res[invoice.id] = invoice.previous_balance - \
-                (invoice.to_pay - invoice.amount_total)
+            if (invoice.previous_invoice_id and
+                invoice.previous_invoice_id.date_invoice ==
+                invoice.date_invoice):
+                # We can't see any payments made on the same day, so any
+                # additional invoice during a day will see 0.0
+                res[invoice.id] = 0.0
+            else:
+                res[invoice.id] = sum((
+                    invoice.previous_balance,
+                    invoice.amount_total,
+                    -1 * invoice.to_pay,
+                ))
         return res
 
     _columns = {

--- a/invoice_print_report_balance_payment/account_invoice.py
+++ b/invoice_print_report_balance_payment/account_invoice.py
@@ -75,8 +75,8 @@ class account_invoice(orm.Model):
         res = {}
         for invoice in self.browse(cr, uid, ids, context=context):
             if (invoice.previous_invoice_id and
-                invoice.previous_invoice_id.date_invoice ==
-                invoice.date_invoice):
+                    invoice.previous_invoice_id.date_invoice ==
+                    invoice.date_invoice):
                 # We can't see any payments made on the same day, so any
                 # additional invoice during a day will see 0.0
                 res[invoice.id] = 0.0

--- a/invoice_print_report_balance_payment/account_invoice.py
+++ b/invoice_print_report_balance_payment/account_invoice.py
@@ -31,11 +31,17 @@ class account_invoice(orm.Model):
         res = {}
         for invoice in self.browse(cr, uid, ids, context=context):
             domain = [
+                # To have a consistent ordering in invoices, accept either
+                # invoices from before, or the same day with a smaller id
+                '|',
                 ('date_invoice', '<', invoice.date_invoice),
+                '&',
+                ('date_invoice', '=', invoice.date_invoice),
+                ('id', '<', invoice.id),
                 ('partner_id', '=', invoice.partner_id.id),
             ]
             search_result = self.search(
-                cr, uid, domain, limit=1, order='date_invoice desc')
+                cr, uid, domain, limit=1, order='date_invoice desc, id desc')
             res[invoice.id] = search_result[0] if search_result else False
         return res
 

--- a/invoice_print_report_balance_payment/tests/__init__.py
+++ b/invoice_print_report_balance_payment/tests/__init__.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+###############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from . import (
+    test_balance,
+)
+
+checks = [
+    test_balance,
+]

--- a/invoice_print_report_balance_payment/tests/test_balance.py
+++ b/invoice_print_report_balance_payment/tests/test_balance.py
@@ -267,7 +267,3 @@ class TestInvoiceBalance(TransactionCase):
         self.assertEquals(second.to_pay,
                           35,
                           "5$ + 30$")
-
-
-
-

--- a/invoice_print_report_balance_payment/tests/test_balance.py
+++ b/invoice_print_report_balance_payment/tests/test_balance.py
@@ -190,13 +190,23 @@ class TestInvoiceBalance(TransactionCase):
         self._create_invoice(50, "{0}-01-07".format(YEAR))
         self._create_payment(40, "{0}-01-10".format(YEAR))
 
-        second = self._create_invoice(50, "{0}-02-07".format(YEAR))
+        second = self.inv_obj.browse(
+            cr, uid,
+            self._create_invoice(50, "{0}-02-07".format(YEAR)),
+        )
         new = self.inv_obj.browse(
             cr, uid,
             self._create_invoice(15, "{0}-02-07".format(YEAR)),
         )
 
-        self.assertEquals(new.previous_invoice_id.id, second,
+        self.assertEquals(second.previous_balance, 50,
+                          "50$ - 40$")
+        self.assertEquals(second.to_pay, 60,
+                          "10 $ + 50$")
+        self.assertEquals(second.payment_total, 40,
+                          "40$ payments")
+
+        self.assertEquals(new.previous_invoice_id.id, second.id,
                           "Previous should be second invoice")
 
         self.assertEquals(new.previous_balance, 75,

--- a/invoice_print_report_balance_payment/tests/test_balance.py
+++ b/invoice_print_report_balance_payment/tests/test_balance.py
@@ -1,0 +1,209 @@
+# -*- encoding: utf-8 -*-
+###############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from __future__ import unicode_literals
+
+import datetime
+
+from openerp import netsvc
+from openerp.tests.common import TransactionCase
+
+YEAR = datetime.date.today().year
+
+
+class TestInvoiceBalance(TransactionCase):
+    """ Test Invoice Balance Computation """
+
+    def setUp(self):
+        super(TestInvoiceBalance, self).setUp()
+        self._setup_partner()
+        self._setup_product()
+        self.inv_obj = self.registry("account.invoice")
+
+    def _setup_partner(self):
+        partner_obj = self.registry("res.partner")
+        self.partner_id = self.ref("base.res_partner_12")
+        self.account_id = partner_obj.browse(
+            self.cr, self.uid, self.partner_id,
+        ).property_account_receivable.id
+
+    def _setup_product(self):
+        self.product_id = self.ref("product.product_product_1")
+
+    def _create_invoice(self, amount, date):
+        cr, uid = self.cr, self.uid
+        invoice_obj = self.inv_obj
+        invoice_line_obj = self.registry("account.invoice.line")
+
+        line_vals = invoice_line_obj.default_get(
+            cr, uid, invoice_line_obj._all_columns)
+        line_vals.update(
+            invoice_line_obj.product_id_change(
+                cr, uid, [], self.product_id, uom_id=line_vals.get("uom_id"),
+                qty=1, partner_id=self.partner_id,
+            )["value"]
+        )
+        line_vals.update({
+            "product_id": self.product_id,
+            "account_id": self.ref("account.a_sale"),
+            "price_unit": amount,
+            "quantity": 1,
+        })
+        vals = invoice_obj.default_get(cr, uid, invoice_obj._all_columns)
+        vals.update({
+            "partner_id": self.partner_id,
+            "account_id": self.account_id,
+            "date_invoice": date,
+        })
+        vals.update(
+            invoice_obj.onchange_partner_id(cr, uid, [], "out_invoice",
+                                            self.partner_id, date)["value"]
+        )
+        vals["invoice_line"] = [(0, 0, line_vals)]
+        inv = invoice_obj.create(cr, uid, vals)
+        invoice_obj.button_reset_taxes(cr, uid, [inv])
+        wf_service = netsvc.LocalService("workflow")
+        wf_service.trg_validate(
+            uid, 'account.invoice', inv, 'invoice_open', cr)
+        return inv
+
+    def _create_payment(self, amount, date):
+        cr, uid = self.cr, self.uid
+        voucher_obj = self.registry("account.voucher")
+        vals = voucher_obj.default_get(
+            cr, uid, voucher_obj._all_columns,
+            context={
+                "default_partner_id": self.partner_id,
+                "default_type": "receipt",
+                "default_amount": amount,
+                "default_date": date,
+            }
+        )
+        vals.update(
+            voucher_obj.onchange_partner_id(
+                cr, uid, [],
+                self.partner_id, vals["journal_id"], amount,
+                vals["currency_id"], "receipt", date,
+            )["value"]
+        )
+        if vals["line_dr_ids"]:
+            vals["line_dr_ids"] = [(0, 0, v) for v in vals["line_dr_ids"]]
+        if vals["line_cr_ids"]:
+            vals["line_cr_ids"] = [(0, 0, v) for v in vals["line_cr_ids"]]
+
+        vals.update(
+            voucher_obj.onchange_line_ids(
+                cr, uid, [],
+                [(5, False, False)] + vals["line_dr_ids"],
+                [(5, False, False)] + vals["line_cr_ids"],
+                vals['amount'], vals['currency_id'], vals['type'],
+            )["value"]
+        )
+
+        voucher_id = voucher_obj.create(cr, uid, vals)
+        voucher_obj.proforma_voucher(cr, uid, [voucher_id])
+
+    def test_basic(self):
+        cr, uid = self.cr, self.uid
+        inv = self.inv_obj.browse(
+            cr, uid,
+            self._create_invoice(50, "{0}-01-07".format(YEAR))
+        )
+
+        self.assertEquals(inv.previous_invoice_id.id, False,
+                          "No previous invoice expected")
+
+        self.assertEquals(inv.previous_balance, 0,
+                          "Previous balance should be 0 for first invoice")
+
+        self.assertEquals(inv.to_pay, 50,
+                          "To Pay should be 50")
+
+        self.assertEquals(inv.payment_total, 0,
+                          "No previous payments")
+
+    def test_previous_paid(self):
+        cr, uid = self.cr, self.uid
+        first = self._create_invoice(50, "{0}-01-07".format(YEAR))
+        self._create_payment(50, "{0}-01-10".format(YEAR))
+
+        new = self.inv_obj.browse(
+            cr, uid,
+            self._create_invoice(50, "{0}-02-07".format(YEAR)),
+        )
+
+        self.assertEquals(new.previous_invoice_id.id, first,
+                          "Previous should be first invoice")
+
+        self.assertEquals(new.previous_balance, 50,
+                          "Previous balance should be 50")
+
+        self.assertEquals(new.to_pay, 50,
+                          "To Pay should be 50")
+
+        self.assertEquals(new.payment_total, 50,
+                          "Previous payments should be 50")
+
+    def test_partially_paid(self):
+        cr, uid = self.cr, self.uid
+        first = self._create_invoice(50, "{0}-01-07".format(YEAR))
+        self._create_payment(20, "{0}-01-10".format(YEAR))
+
+        new = self.inv_obj.browse(
+            cr, uid,
+            self._create_invoice(50, "{0}-02-07".format(YEAR)),
+        )
+
+        self.assertEquals(new.previous_invoice_id.id, first,
+                          "Previous should be first invoice")
+
+        self.assertEquals(new.previous_balance, 50,
+                          "Previous balance should be 50")
+
+        self.assertEquals(new.to_pay, 80,
+                          "To Pay should be 80")
+
+        self.assertEquals(new.payment_total, 20,
+                          "Previous payments should be 50")
+
+    def test_same_day(self):
+        cr, uid = self.cr, self.uid
+        self._create_invoice(50, "{0}-01-07".format(YEAR))
+        self._create_payment(40, "{0}-01-10".format(YEAR))
+
+        second = self._create_invoice(50, "{0}-02-07".format(YEAR))
+        new = self.inv_obj.browse(
+            cr, uid,
+            self._create_invoice(15, "{0}-02-07".format(YEAR)),
+        )
+
+        self.assertEquals(new.previous_invoice_id.id, second,
+                          "Previous should be second invoice")
+
+        self.assertEquals(new.previous_balance, 75,
+                          "Previous balance should be 75")
+
+        self.assertEquals(new.to_pay, 75,
+                          "To Pay should be 75")
+
+        self.assertEquals(new.payment_total, 0,
+                          "Previous payments should be 0")


### PR DESCRIPTION
This branch attempts to get a reasonable behaviour when multiple invoices are created on the same day. The previous behaviour give the following results when there are multiple invoices, credits or payments on the same day:

| Date | Invoice/Payment | previous_balance | payment_total | to_pay | previous |
| --- | --- | --- | --- | --- | --- |
| 2015-02-01 | INV01: 50$ | 0 $ | 0 $ | 50 $ |  |
| 2015-02-02 | Payment: 40$ |  |  | 10 $ |  |
| 2015-02-08 | INV02: 50$ | 50 $ | 40$ | 60 $ | INV01 |
| 2015-02-08 | INV03: 10$ | 50 $ | -10$ | 70 $ | INV01 |

With this PR, the behaviour becomes the following:
- Previous Invoice is the last invoice on or before an invoice date, sorted by (date desc, id desc). For multiple invoices on the same day, this allows a repeatable order.
- Payments made on the same day as an invoice are considered to be made before the first invoice of the day. This invoice will have all the payments between the last previous invoice and the payments on the same day. Other invoices will get payments = 0.
- The amount to pay is coherent within invoices. The first one does not consider the following invoice amounts, and the subsequent invoice/credits consider the previous ones.

| Date | Invoice/Payment | previous_balance | payment_total | to_pay | previous |
| --- | --- | --- | --- | --- | --- |
| 2015-02-01 | INV01: 50$ | 0 $ | 0 $ | 50 $ |  |
| 2015-02-02 | Payment: 40$ |  |  | 10 $ |  |
| 2015-02-08 | INV02: 50$ | 50 $ | 40$ | 60 $ | INV01 |
| 2015-02-08 | INV03: 10$ | 60 $ | 0$ | 70 $ | INV02 |
