### PR TITLE
[10.0][FIX] account_invoice_production_lot: only compute stock.production.lot related to move done

### DIFF
--- a/account_invoice_production_lot/README.rst
+++ b/account_invoice_production_lot/README.rst
@@ -48,6 +48,7 @@ Contributors
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Alessio Gerace <alessio.gerace@agilebg.com>
 * Vicent Cubells <vicent.cubells@tecnativa.com>
+* Alex Comba <alex.comba@agilebg.com>
 
 Maintainer
 ----------

--- a/account_invoice_production_lot/__manifest__.py
+++ b/account_invoice_production_lot/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Invoice Production Lots",
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.1.1",
     "author": "Agile Business Group,"
               "Tecnativa,"
               "Odoo Community Association (OCA)",

--- a/account_invoice_production_lot/models/account_invoice.py
+++ b/account_invoice_production_lot/models/account_invoice.py
@@ -36,7 +36,8 @@ class AccountInvoiceLine(models.Model):
             if not line.order_line_ids:
                 return
             line.prod_lot_ids = self.mapped(
-                'order_line_ids.procurement_ids.move_ids.lot_ids')
+                'order_line_ids.procurement_ids.move_ids').filtered(
+                lambda move: move.state == 'done').lot_ids
 
     @api.multi
     def _compute_line_lots(self):

--- a/account_invoice_production_lot/models/account_invoice.py
+++ b/account_invoice_production_lot/models/account_invoice.py
@@ -35,9 +35,11 @@ class AccountInvoiceLine(models.Model):
         for line in self:
             if not line.order_line_ids:
                 return
-            line.prod_lot_ids = self.mapped(
-                'order_line_ids.procurement_ids.move_ids').filtered(
-                lambda move: move.state == 'done').lot_ids
+            move_ids = self.mapped(
+                'order_line_ids.procurement_ids.move_ids')
+            prod_lot_ids = move_ids.filtered(
+                lambda move: move.state == 'done').mapped('lot_ids')
+            line.prod_lot_ids = prod_lot_ids
 
     @api.multi
     def _compute_line_lots(self):

--- a/account_invoice_production_lot/tests/test_invoice_production_lot.py
+++ b/account_invoice_production_lot/tests/test_invoice_production_lot.py
@@ -2,6 +2,7 @@
 # Copyright 2011 Domsense s.r.l. <http://www.domsense.com>
 # Copyright 2013 Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 # Copyright 2017 Vicent Cubells <vicent.cubells@tecnativa.com>
+# Copyright 2018 Alex Comba <alex.comba@agilebg.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests import common
@@ -17,6 +18,7 @@ class TestProdLot(common.SavepointCase):
         cls.product = cls.env['product.product'].create({
             'name': 'Product Test',
             'type': 'product',
+            'tracking': 'lot',
         })
         cls.sale = cls.env['sale.order'].create({
             'partner_id': cls.partner.id,
@@ -25,7 +27,7 @@ class TestProdLot(common.SavepointCase):
             'order_line': [(0, 0, {
                 'name': cls.product.name,
                 'product_id': cls.product.id,
-                'product_uom_qty': 2,
+                'product_uom_qty': 4,
                 'product_uom': cls.product.uom_id.id,
                 'price_unit': 15.0,
             })],
@@ -42,7 +44,17 @@ class TestProdLot(common.SavepointCase):
         cls.customer_location = cls.env.ref('stock.stock_location_customers')
         cls.picking_type_out = cls.env.ref('stock.picking_type_out')
 
-    def test_invoice_product_lot(self):
+    def qty_on_hand(self, product, location, quantity, lot):
+        """Update Product quantity."""
+        wiz = self.env['stock.change.product.qty'].create({
+            'location_id': location.id,
+            'product_id': product.id,
+            'new_quantity': quantity,
+            'lot_id': lot.id,
+        })
+        wiz.change_product_qty()
+
+    def test_00_sale_stock_invoice_product_lot(self):
         # confirm quotation
         self.sale.action_confirm()
         picking = self.sale.picking_ids[:1]
@@ -52,23 +64,93 @@ class TestProdLot(common.SavepointCase):
         picking.do_prepare_partial()
         self.env['stock.pack.operation'].create({
             'product_id': self.product.id,
-            'product_qty': 1,
+            'product_qty': 2,
             'product_uom_id': self.product.uom_id.id,
             'location_id': self.stock_location.id,
             'location_dest_id': self.customer_location.id,
             'picking_id': picking.id,
-            'pack_lot_ids': [(0, 0, {'lot_id': self.lot1.id, 'qty': 1.0})],
+            'pack_lot_ids': [(0, 0, {'lot_id': self.lot1.id, 'qty': 2.0})],
         })
         self.env['stock.pack.operation'].create({
             'product_id': self.product.id,
-            'product_qty': 1,
+            'product_qty': 2,
             'product_uom_id': self.product.uom_id.id,
             'location_id': self.stock_location.id,
             'location_dest_id': self.customer_location.id,
             'picking_id': picking.id,
-            'pack_lot_ids': [(0, 0, {'lot_id': self.lot2.id, 'qty': 1.0})],
+            'pack_lot_ids': [(0, 0, {'lot_id': self.lot2.id, 'qty': 2.0})],
         })
         picking.do_transfer()
+        # create invoice
+        inv_id = self.sale.action_invoice_create()
+        invoice = self.env['account.invoice'].browse(inv_id)
+        self.assertEqual(len(invoice.invoice_line_ids), 1)
+        line = invoice.invoice_line_ids
+        # We must have two lots
+        self.assertEqual(len(line.prod_lot_ids.ids), 2)
+        self.assertIn('Lot 1', line.lot_formatted_note)
+        self.assertIn('Lot 2', line.lot_formatted_note)
+
+    def test_01_sale_stock_delivery_partial_invoice_product_lot(self):
+        # update quantities with their related lots
+        self.qty_on_hand(self.product, self.stock_location, 3, self.lot1)
+        self.qty_on_hand(self.product, self.stock_location, 3, self.lot2)
+        # confirm quotation
+        self.sale.action_confirm()
+        picking = self.sale.picking_ids[:1]
+        picking.action_confirm()
+        picking.action_assign()
+        self.assertEqual(len(picking.mapped('pack_operation_ids')), 1)
+        self.assertEqual(len(picking.mapped(
+            'pack_operation_ids.pack_lot_ids')), 2)
+        operation_lot1 = picking.pack_operation_ids.pack_lot_ids[0]
+        self.assertIn('Lot 1', operation_lot1.lot_id.name)
+        self.assertEqual(operation_lot1.qty_todo, 3)
+        operation_lot2 = picking.pack_operation_ids.pack_lot_ids[1]
+        self.assertIn('Lot 2', operation_lot2.lot_id.name)
+        self.assertEqual(operation_lot2.qty_todo, 1)
+        # deliver partially only one lot
+        operation_lot1.action_add_quantity(2)
+        picking.pack_operation_product_ids.write({'qty_done': 2})
+        backorder_wiz_id = picking.do_new_transfer()['res_id']
+        backorder_wiz = self.env['stock.backorder.confirmation'].browse(
+            [backorder_wiz_id])
+        backorder_wiz.process()
+        # create invoice
+        inv_id = self.sale.action_invoice_create()
+        invoice = self.env['account.invoice'].browse(inv_id)
+        self.assertEqual(len(invoice.invoice_line_ids), 1)
+        line = invoice.invoice_line_ids
+        # We must have only one lot
+        self.assertEqual(len(line.prod_lot_ids.ids), 1)
+        self.assertIn('Lot 1', line.lot_formatted_note)
+
+    def test_02_sale_stock_delivery_partial_invoice_product_lot(self):
+        # update quantities with their related lots
+        self.qty_on_hand(self.product, self.stock_location, 3, self.lot1)
+        self.qty_on_hand(self.product, self.stock_location, 3, self.lot2)
+        # confirm quotation
+        self.sale.action_confirm()
+        picking = self.sale.picking_ids[:1]
+        picking.action_confirm()
+        picking.action_assign()
+        self.assertEqual(len(picking.mapped('pack_operation_ids')), 1)
+        self.assertEqual(len(picking.mapped(
+            'pack_operation_ids.pack_lot_ids')), 2)
+        operation_lot1 = picking.pack_operation_ids.pack_lot_ids[0]
+        self.assertIn('Lot 1', operation_lot1.lot_id.name)
+        self.assertEqual(operation_lot1.qty_todo, 3)
+        operation_lot2 = picking.pack_operation_ids.pack_lot_ids[1]
+        self.assertIn('Lot 2', operation_lot2.lot_id.name)
+        self.assertEqual(operation_lot2.qty_todo, 1)
+        # deliver partially both lots
+        operation_lot1.action_add_quantity(2)
+        operation_lot2.action_add_quantity(1)
+        picking.pack_operation_product_ids.write({'qty_done': 3})
+        backorder_wiz_id = picking.do_new_transfer()['res_id']
+        backorder_wiz = self.env['stock.backorder.confirmation'].browse(
+            [backorder_wiz_id])
+        backorder_wiz.process()
         # create invoice
         inv_id = self.sale.action_invoice_create()
         invoice = self.env['account.invoice'].browse(inv_id)

--- a/account_invoice_production_lot/tests/test_invoice_production_lot.py
+++ b/account_invoice_production_lot/tests/test_invoice_production_lot.py
@@ -123,6 +123,7 @@ class TestProdLot(common.SavepointCase):
         line = invoice.invoice_line_ids
         # We must have only one lot
         self.assertEqual(len(line.prod_lot_ids.ids), 1)
+        self.assertEqual(line.prod_lot_ids.id, self.lot1.id)
         self.assertIn('Lot 1', line.lot_formatted_note)
 
     def test_02_sale_stock_delivery_partial_invoice_product_lot(self):
@@ -158,5 +159,7 @@ class TestProdLot(common.SavepointCase):
         line = invoice.invoice_line_ids
         # We must have two lots
         self.assertEqual(len(line.prod_lot_ids.ids), 2)
+        self.assertIn(self.lot1.id, line.prod_lot_ids.ids)
+        self.assertIn(self.lot2.id, line.prod_lot_ids.ids)
         self.assertIn('Lot 1', line.lot_formatted_note)
         self.assertIn('Lot 2', line.lot_formatted_note)


### PR DESCRIPTION
This patch fixes the following use case scenario.

Steps to reproduce:

* create a new product 'Product Test': stockable and tracking by lots
* update its quantity to 3 with new lot 'Lot1'
* update its quantity to 3 with new lot 'Lot2'
* sale 4 of 'Product Test'
* on the delivery, split the lots and set To Do quantities as 3 for Lot1 and leave 0 for Lot2
* validate the delivery and create a backorder

Current behavior:

the field 'Production Lots' of the invoice generated is filled with both lots and, consequently,
the invoice report will also contain info related to the lot not delivered yet.

Expected behavior:

the invoice report only contains info related to the lot involved in the delivery, which is Lot1.