### PR TITLE
[IMP] account_invoice_production_lot: serials rendering

### DIFF
--- a/account_invoice_production_lot/models/account_invoice.py
+++ b/account_invoice_production_lot/models/account_invoice.py
@@ -2,6 +2,7 @@
 # Copyright 2013 Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 # Copyright 2017 Vicent Cubells <vicent.cubells@tecnativa.com>
 # Copyright 2018 Tecnativa - Pedro M. Baeza
+# Copyright 2020 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -30,19 +31,21 @@ class AccountInvoiceLine(models.Model):
 
     @api.multi
     def _compute_line_lots(self):
-        for line in self:
+        """Depending on traceability, render one lot by line, or serials
+           separated by commas"""
+        for line in self.filtered('prod_lot_ids'):
+            if line.product_id.tracking == 'serial':
+                line.lot_formatted_note = (
+                    line.prod_lot_ids and '{}: {}'.format(
+                        _('S/N'), ', '.join(line.prod_lot_ids.mapped('name'))
+                    ))
+                continue
             note = '<ul>'
             lot_strings = []
             for sml in line.mapped('move_line_ids.move_line_ids'):
-                if sml.lot_id:
-                    if sml.product_id.tracking == 'serial':
-                        lot_strings.append('<li>%s %s</li>' % (
-                            _('S/N'), sml.lot_id.name,
-                        ))
-                    else:
-                        lot_strings.append('<li>%s %s (%s)</li>' % (
-                            _('Lot'), sml.lot_id.name, sml.qty_done,
-                        ))
+                lot_strings.append('<li>%s %s (%s)</li>' % (
+                    _('Lot'), sml.lot_id.name, sml.qty_done,
+                ))
             if lot_strings:
                 note += ' '.join(lot_strings)
                 note += '</ul>'


### PR DESCRIPTION
When the product traceability is by unique serial numbers, each unit on
the invoice line is going to be shown on a separate row, wich can result
in quite long reports. So in these cases is preferible to show them
altogether separated by commas.

cc @Tecnativa TT21255