### PR TITLE
[IMP] account_invoice_report_due_list: allways print the same way

### DIFF
--- a/account_invoice_report_due_list/views/report_invoice.xml
+++ b/account_invoice_report_due_list/views/report_invoice.xml
@@ -5,10 +5,10 @@
 
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//p[@t-field='o.date_due']/.." position="attributes">
-            <attribute name="t-att-class">'hidden' if o.multi_due else 'col-xs-2'</attribute>
+            <attribute name="t-att-class">'hidden'</attribute>
         </xpath>
         <xpath expr="//span[@t-field='o.payment_term_id.note']" position="after">
-            <div class="row" t-if="o.multi_due">
+            <div class="row">
                 <div class="col-4">
                     <table class="table table-striped">
                         <thead>


### PR DESCRIPTION
- It's annoying to have the due date rendered in different positions
depending on if it's a single due or there are several. With this
change, we render it always the same way.

cc @Tecnativa TT21255

FW Port from https://github.com/OCA/account-invoice-reporting/pull/132