### PR TITLE
[FIX] account_invoice_report_due_list: empty table

### DIFF
--- a/account_invoice_report_due_list/views/report_invoice.xml
+++ b/account_invoice_report_due_list/views/report_invoice.xml
@@ -8,7 +8,8 @@
             <attribute name="t-att-class">'hidden'</attribute>
         </xpath>
         <xpath expr="//span[@t-field='o.payment_term_id.note']" position="after">
-            <div class="row">
+            <t t-set="due_list" t-value="o.get_multi_due_list()"/>
+            <div class="row" t-if="due_list">
                 <div class="col-4">
                     <table class="table table-striped">
                         <thead>
@@ -18,7 +19,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr t-foreach="o.get_multi_due_list()" t-as="due_tuple">
+                            <tr t-foreach="due_list" t-as="due_tuple">
                                 <td>
                                     <span t-esc="due_tuple[0]" t-esc-options="{'widget': 'date'}"/>
                                 </td>


### PR DESCRIPTION
When no due dates are available we get an empty table. This patch fixes
it so the due list table is only visible when due dates are computed.

@Tecnativa TT21247

FW Port of https://github.com/OCA/account-invoice-reporting/pull/134 