### PR TITLE
[12.0] remove PyPDF2 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ install:
  - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
  - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
  - travis_install_nightly
- - pip install PyPDF2==1.18
 
 script:
     - travis_run_tests


### PR DESCRIPTION
Found no import from the current code.