### PR TITLE
[11.0][FIX] account_invoice_production_lot: display serial numbers even if sale.group_sale_layout is enabled

### DIFF
--- a/account_invoice_production_lot/report/report_invoice.xml
+++ b/account_invoice_production_lot/report/report_invoice.xml
@@ -9,4 +9,12 @@
         </span>
     </template>
 
+    <template id="report_invoice_layouted" inherit_id="sale.report_invoice_layouted">
+        <xpath expr="//t[@t-foreach=&quot;layout_category['lines']&quot;]//span[@t-field='l.name']" position="after">
+            <t t-if="l[:1].lot_formatted_note">
+                <div style="margin-left:25px;" t-field="l[:1].lot_formatted_note"/>
+            </t>
+        </xpath>
+    </template>
+
 </odoo>


### PR DESCRIPTION
Steps to reproduce:

* enable 'Personalize sales order and invoice report' technical setting (sale.group_sale_layout)
* deliver a product with 'Track lots or serial numbers' enabled
* create and print the invoice

Current behavior: serial number is not displayed on the invoice report

Expected behavior: serial number is displayed on the invoice report