### PR TITLE
[FIX] account_invoice_report_due_list: avoid breaking due list block

### DIFF
--- a/account_invoice_report_due_list/views/report_invoice.xml
+++ b/account_invoice_report_due_list/views/report_invoice.xml
@@ -9,7 +9,7 @@
         </xpath>
         <xpath expr="//span[@t-field='o.payment_term_id.note']" position="after">
             <t t-set="due_list" t-value="o.get_multi_due_list()"/>
-            <div class="row" t-if="due_list">
+            <div class="row" t-if="due_list" style="page-break-inside: avoid;">
                 <div class="col-4">
                     <table class="table table-striped">
                         <thead>


### PR DESCRIPTION
When the due list table falls in a page break it's not properly
rendered. It's more convinient to keep its integrity anyway.

@Tecnativa TT23478