### PR TITLE
[12.0][IMP] Enhance fool-proof-ness of account_invoice_report_hide_line

### DIFF
--- a/account_invoice_report_hide_line/views/account_invoice_view.xml
+++ b/account_invoice_report_hide_line/views/account_invoice_view.xml
@@ -9,7 +9,7 @@
         <field name="inherit_id" ref="account.invoice_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='product_id']" position="before">
-                <field name="show_in_report"/>
+                <field name="show_in_report" attrs="{'readonly':[('price_unit','>','0.0')]}"/>
             </xpath>
         </field>
     </record>

--- a/account_invoice_report_hide_line/views/report_invoice.xml
+++ b/account_invoice_report_hide_line/views/report_invoice.xml
@@ -5,7 +5,7 @@
 
     <template id="report_invoice_document_show_in_report" inherit_id="account.report_invoice_document">
       <xpath expr="//t[@t-foreach='o.invoice_line_ids']" position="attributes">
-        <attribute name="t-foreach">o.invoice_line_ids.filtered(lambda x: x.show_in_report)</attribute>
+        <attribute name="t-foreach">o.invoice_line_ids.filtered(lambda x: (x.show_in_report or x.price_unit>0))</attribute>
       </xpath>
     </template>
 


### PR DESCRIPTION
This ensures that the hiding checkbox is read-only when unit price is > 0.0 and also renders lines that have the checkox checked but the price > 0.0. Current situation allows for checking the checkbox on lines with unit price > 0.0 and also to skip rendering lines that have unit price > 0.0 which can lead to strange results (i.e. sum does not correspond to items listed).