### PR TITLE
[14.0][FIX] account_invoice_report_grouped_by_picking: invoice line without product

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -49,7 +49,8 @@ class AccountMove(models.Model):
                         picking_dict[key] += qty
                         remaining_qty -= qty
             if not float_is_zero(
-                remaining_qty, precision_rounding=line.product_id.uom_id.rounding
+                remaining_qty,
+                precision_rounding=line.product_id.uom_id.rounding or 0.01,
             ):
                 lines_dict[line] = remaining_qty
         no_picking = [


### PR DESCRIPTION
Odoo returns an error when there is a note or section line on the invoice.
In older versions like odoo 12 it also happens. Tested in runbot.