### PR TITLE
13.0 [FIX] account_invoice_report_due_list, error on empty date_maturity

### DIFF
--- a/account_invoice_report_due_list/models/account_move.py
+++ b/account_invoice_report_due_list/models/account_move.py
@@ -30,11 +30,12 @@ class AccountMove(models.Model):
         due_list = []
         if self.type in ["in_invoice", "out_refund"]:
             due_move_line_ids = self.line_ids.filtered(
-                lambda ml: ml.account_id.internal_type == "payable"
+                lambda ml: ml.account_id.internal_type == "payable" and ml.date_maturity
             )
         else:
             due_move_line_ids = self.line_ids.filtered(
                 lambda ml: ml.account_id.internal_type == "receivable"
+                and ml.date_maturity
             )
         if self.currency_id != self.company_id.currency_id:
             due_list = [


### PR DESCRIPTION
When the date_maturity field does not contain a date, the module throws an error, trying to convert the field to a string with strftime (). 

In addition, this error does not allow inserting accounting entries in the accounting.