### PR TITLE
[14.0][IMP] account_invoice_report_grouped_by_picking: No display repeated lines for refund invoices without no returned quantities

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -52,7 +52,7 @@ class AccountMove(models.Model):
                         remaining_qty -= qty
             # To avoid to print duplicate lines because the invoice is a refund
             # without returned goods to refund.
-            if self.type == "out_refund" and not has_returned_qty:
+            if self.move_type == "out_refund" and not has_returned_qty:
                 remaining_qty = 0.0
                 for key in picking_dict:
                     picking_dict[key] = abs(picking_dict[key])

--- a/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
+++ b/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
@@ -5,6 +5,7 @@
 
 from lxml import html
 
+from odoo import fields
 from odoo.tests.common import SavepointCase
 
 
@@ -123,3 +124,28 @@ class TestAccountInvoiceGroupPicking(SavepointCase):
         groups = invoice.lines_grouped_by_picking()
         self.assertEqual(len(groups), 1)
         self.assertEqual(groups[0]["picking"], picking_return)
+
+    def test_account_invoice_return_without_returned_good(self):
+        self.sale.action_confirm()
+        picking = self.sale.picking_ids[:1]
+        picking.action_confirm()
+        picking.move_line_ids.write({"qty_done": 1})
+        picking.action_done()
+        invoice = self.sale._create_invoices()
+        invoice.post()
+        # Refund invoice without return picking
+        move_reversal = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create(
+                {
+                    "date": fields.Date.today(),
+                    "reason": "no reason",
+                    "refund_method": "refund",
+                }
+            )
+        )
+        reversal = move_reversal.reverse_moves()
+        refund_invoice = self.env["account.move"].browse(reversal["res_id"])
+        groups = refund_invoice.lines_grouped_by_picking()
+        self.assertEqual(len(groups), 2)

--- a/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
+++ b/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
@@ -130,9 +130,9 @@ class TestAccountInvoiceGroupPicking(SavepointCase):
         picking = self.sale.picking_ids[:1]
         picking.action_confirm()
         picking.move_line_ids.write({"qty_done": 1})
-        picking.action_done()
+        picking._action_done()
         invoice = self.sale._create_invoices()
-        invoice.post()
+        invoice.action_post()
         # Refund invoice without return picking
         move_reversal = (
             self.env["account.move.reversal"]


### PR DESCRIPTION
Cherry-pick of https://github.com/OCA/account-invoice-reporting/pull/162