### PR TITLE
[12.0][FIX] account_reporting_weight: Show negative weight in correctly invoice types

### DIFF
--- a/account_reporting_weight/reports/account_invoice_report.py
+++ b/account_reporting_weight/reports/account_invoice_report.py
@@ -22,7 +22,7 @@ class AccountInvoiceReport(models.Model):
         select_str = super()._sub_select()
         select_str += """
             , SUM(
-                (pr.weight * invoice_type.sign) * ail.quantity / u.factor * u2.factor
+                pr.weight * invoice_type.sign_qty * ail.quantity / u.factor * u2.factor
             )
             AS weight
             """


### PR DESCRIPTION
Show negative weight in correctly invoice types (out_refund + in_invoice) https://github.com/odoo/odoo/blob/12.0/addons/account/report/account_invoice_report.py#L147-L150
It's related to https://github.com/OCA/account-invoice-reporting/pull/182

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT29080