### PR TITLE
[FIX] account_invoice_report_grouped_by_picking: Invoice line are not  displayed for refund invoices without stock moves

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -52,7 +52,11 @@ class AccountMove(models.Model):
                         remaining_qty -= qty
             # To avoid to print duplicate lines because the invoice is a refund
             # without returned goods to refund.
-            if self.type == "out_refund" and not has_returned_qty:
+            if (
+                self.type == "out_refund"
+                and line.move_line_ids
+                and not has_returned_qty
+            ):
                 remaining_qty = 0.0
                 for key in picking_dict:
                     picking_dict[key] = abs(picking_dict[key])


### PR DESCRIPTION
cc @Tecnativa TT29132
ping @carlosdauden @chienandalu 