### PR TITLE
[13.0][FIX] account_invoice_report_grouped_by_picking: No change sign for credit notes created from reversal moves instead of sale order invoicing process after picking reverse transfer.

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -24,12 +24,13 @@ class AccountMove(models.Model):
         self.ensure_one()
         picking_dict = OrderedDict()
         lines_dict = OrderedDict()
-        sign = -1.0 if self.type == "out_refund" else 1.0
+        # Not change sign if the credit note has been created from reverse move option
+        # instead of sale order invoicing process after picking reverse transfer
+        sign = -1.0 if self.type == "out_refund" and not self.reversed_entry_id else 1.0
         # Let's get first a correspondance between pickings and sales order
         so_dict = {x.sale_id: x for x in self.picking_ids if x.sale_id}
         # Now group by picking by direct link or via same SO as picking's one
         for line in self.invoice_line_ids:
-            has_returned_qty = False
             remaining_qty = line.quantity
             for move in line.move_line_ids:
                 key = (move.picking_id, line)
@@ -37,7 +38,6 @@ class AccountMove(models.Model):
                 qty = 0
                 if move.location_id.usage == "customer":
                     qty = -move.quantity_done * sign
-                    has_returned_qty = True
                 elif move.location_dest_id.usage == "customer":
                     qty = move.quantity_done * sign
                 picking_dict[key] += qty
@@ -50,16 +50,6 @@ class AccountMove(models.Model):
                         qty = so_line.product_uom_qty
                         picking_dict[key] += qty
                         remaining_qty -= qty
-            # To avoid to print duplicate lines because the invoice is a refund
-            # without returned goods to refund.
-            if (
-                self.type == "out_refund"
-                and line.move_line_ids
-                and not has_returned_qty
-            ):
-                remaining_qty = 0.0
-                for key in picking_dict:
-                    picking_dict[key] = abs(picking_dict[key])
             if not float_is_zero(
                 remaining_qty,
                 precision_rounding=line.product_id.uom_id.rounding or 0.01,


### PR DESCRIPTION
cc @Tecnativa  TT29322
 ping @carlosdauden @chienandalu 