### PR TITLE
[FIX] account_invoice_report_grouped_by_picking: filter sections and

### DIFF
--- a/account_invoice_report_grouped_by_picking/README.rst
+++ b/account_invoice_report_grouped_by_picking/README.rst
@@ -49,6 +49,14 @@ Usage
 #. Invoice report will group invoice lines and shows information about sales
    and pickings in every group.
 
+Known issues / Roadmap
+======================
+
+* As a result of the grouping by pickings, we don't support notes and descriptions.
+* Anyways, an invoice with no pickings should be printed as usual. The problem is
+  that in the current state of the report, a heavy refactoring is needed to be able to
+  fallback to the regular behavior in such case.
+
 Bug Tracker
 ===========
 

--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -30,7 +30,7 @@ class AccountMove(models.Model):
         # Let's get first a correspondance between pickings and sales order
         so_dict = {x.sale_id: x for x in self.picking_ids if x.sale_id}
         # Now group by picking by direct link or via same SO as picking's one
-        for line in self.invoice_line_ids:
+        for line in self.invoice_line_ids.filtered(lambda x: not x.display_type):
             remaining_qty = line.quantity
             for move in line.move_line_ids:
                 key = (move.picking_id, line)

--- a/account_invoice_report_grouped_by_picking/readme/ROADMAP.rst
+++ b/account_invoice_report_grouped_by_picking/readme/ROADMAP.rst
@@ -1,0 +1,4 @@
+* As a result of the grouping by pickings, we don't support notes and descriptions.
+* Anyways, an invoice with no pickings should be printed as usual. The problem is
+  that in the current state of the report, a heavy refactoring is needed to be able to
+  fallback to the regular behavior in such case.

--- a/account_invoice_report_grouped_by_picking/static/description/index.html
+++ b/account_invoice_report_grouped_by_picking/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Account Invoice Grouped by Picking</title>
 <style type="text/css">
 
@@ -378,11 +378,12 @@ picking.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -399,8 +400,17 @@ orders.</li>
 and pickings in every group.</li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>As a result of the grouping by pickings, we don’t support notes and descriptions.</li>
+<li>Anyways, an invoice with no pickings should be printed as usual. The problem is
+that in the current state of the report, a heavy refactoring is needed to be able to
+fallback to the regular behavior in such case.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-invoice-reporting/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -408,15 +418,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Carlos Dauden</li>
@@ -432,7 +442,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
notes

Avoid nasty exceptions. In the other hand it would be hard to fit the
concept of sections and notes to the picking groups in which this report
results.

cc @Tecnativa TT29507

ping @pedrobaeza @sergio-teruel 