### PR TITLE
[14.0][IMP] account_comment_template: Include changes from 13.0

### DIFF
--- a/account_comment_template/__manifest__.py
+++ b/account_comment_template/__manifest__.py
@@ -9,7 +9,7 @@
     "summary": "Comments templates on invoice documents",
     "version": "14.0.1.0.0",
     "category": "Sale",
-    "author": "Camptocamp, " "Tecnativa, " "Odoo Community Association (OCA)",
+    "author": "Camptocamp, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-invoice-reporting",
     "license": "AGPL-3",
     "installable": True,

--- a/account_comment_template/models/account_move.py
+++ b/account_comment_template/models/account_move.py
@@ -2,51 +2,12 @@
 # Copyright 2013-2014 Nicolas Bessi (Camptocamp SA)
 # Copyright 2018 Vicent Cubells - Tecnativa
 # Copyright 2019 Iván Todorovich (Druidoo)
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import models
 
 
-class AccountInvoice(models.Model):
-    _inherit = "account.move"
-
-    comment_template1_id = fields.Many2one(
-        "base.comment.template",
-        string="Top Comment Template",
-        domain=[("position", "=", "before_lines")],
-    )
-
-    comment_template2_id = fields.Many2one(
-        "base.comment.template",
-        string="Bottom Comment Template",
-        domain=[("position", "=", "after_lines")],
-    )
-
-    note1 = fields.Html("Top Comment")
-    note2 = fields.Html("Bottom Comment")
-
-    @api.onchange("comment_template1_id")
-    def _set_note1(self):
-        comment = self.comment_template1_id
-        if comment:
-            self.note1 = comment.get_value(self.partner_id.id)
-
-    @api.onchange("comment_template2_id")
-    def _set_note2(self):
-        comment = self.comment_template2_id
-        if comment:
-            self.note2 = comment.get_value(self.partner_id.id)
-
-    @api.onchange("partner_id", "company_id")
-    def _onchange_partner_id_set_templates_and_notes(self):
-        comment_template = self.partner_id.property_comment_template_id
-        if comment_template.position == "before_lines":
-            self.comment_template1_id = comment_template
-        elif comment_template.position == "after_lines":
-            self.comment_template2_id = comment_template
-        # Force note read when changing partner/company
-        # to update to the current partner language.
-        if self.comment_template1_id:
-            self._set_note1()
-        if self.comment_template2_id:
-            self._set_note2()
+class AccountMove(models.Model):
+    _name = "account.move"
+    _inherit = ["account.move", "comment.template"]

--- a/account_comment_template/readme/CONTRIBUTORS.rst
+++ b/account_comment_template/readme/CONTRIBUTORS.rst
@@ -6,6 +6,7 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Pedro M. Baeza
+  * Víctor Martínez
 
 * `DynApps <https://www.dynapps.be>`_:
 

--- a/account_comment_template/tests/test_account_move_report.py
+++ b/account_comment_template/tests/test_account_move_report.py
@@ -1,44 +1,67 @@
 # Copyright 2017 Simone Rubino - Agile Business Group
 # Copyright 2018 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, TransactionCase
 
 
 class TestAccountInvoiceReport(TransactionCase):
-    at_install = False
-    post_install = True
-
     def setUp(self):
-        super(TestAccountInvoiceReport, self).setUp()
+        super().setUp()
+        self.company = self.env.ref("base.main_company")
         self.base_comment_model = self.env["base.comment.template"]
+        self.move_obj = self.env.ref("account.model_account_move")
         self.before_comment = self._create_comment("before_lines")
         self.after_comment = self._create_comment("after_lines")
         self.partner = self.env["res.partner"].create({"name": "Partner Test"})
-        self.invoice_model = self.env["account.move"]
-        self.invoice = self.invoice_model.create(
+        self.partner.base_comment_template_ids = [
+            (4, self.before_comment.id),
+            (4, self.after_comment.id),
+        ]
+        self.income_account = self.env["account.account"].search(
+            [
+                ("user_type_id.name", "=", "Income"),
+                ("company_id", "=", self.company.id),
+            ],
+            limit=1,
+        )
+        self.journal_sale = self.env["account.journal"].create(
             {
-                # "move_type": "out_invoice",
-                # "journal_id":
-                "partner_id": self.partner.id,
-                "comment_template1_id": self.before_comment.id,
-                "comment_template2_id": self.after_comment.id,
+                "name": "Test journal sale",
+                "code": "TST-JRNL-S",
+                "type": "sale",
+                "company_id": self.company.id,
             }
         )
+        move_form = self._create_invoice()
+        self.invoice = move_form.save()
 
-        self.invoice._set_note1()
-        self.invoice._set_note2()
+    def _create_invoice(self):
+        move_form = Form(
+            self.env["account.move"].with_context(default_type="out_invoice")
+        )
+        move_form.partner_id = self.partner
+        move_form.journal_id = self.journal_sale
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.name = "test"
+            line_form.quantity = 1.0
+            line_form.price_unit = 100
+            line_form.account_id = self.income_account
+        return move_form
 
     def _create_comment(self, position):
         return self.base_comment_model.create(
             {
                 "name": "Comment " + position,
+                "company_id": self.company.id,
                 "position": position,
                 "text": "Text " + position,
+                "model_ids": [(6, 0, self.move_obj.ids)],
             }
         )
 
-    def test_comments_in_invoice(self):
+    def test_comments_in_invoice_report(self):
         res = (
             self.env["ir.actions.report"]
             ._get_report_from_name("account.report_invoice")
@@ -47,15 +70,9 @@ class TestAccountInvoiceReport(TransactionCase):
         self.assertRegex(str(res[0]), self.before_comment.text)
         self.assertRegex(str(res[0]), self.after_comment.text)
 
-    def test__onchange_partner_id_set_templates_and_notes(self):
-        self.partner.property_comment_template_id = self.after_comment.id
-        new_invoice = self.env["account.move"].new(
-            {
-                "partner_id": self.partner.id,
-            }
-        )
-        new_invoice._onchange_partner_id_set_templates_and_notes()
-        self.assertEqual(new_invoice.comment_template2_id, self.after_comment)
-        self.partner.property_comment_template_id = self.before_comment.id
-        new_invoice._onchange_partner_id_set_templates_and_notes()
-        self.assertEqual(new_invoice.comment_template1_id, self.before_comment)
+    def test_comments_in_invoice(self):
+        move_form = self._create_invoice()
+        new_invoice = move_form.save()
+        new_invoice._compute_comment_template_ids()
+        self.assertTrue(self.after_comment in new_invoice.comment_template_ids)
+        self.assertTrue(self.before_comment in new_invoice.comment_template_ids)

--- a/account_comment_template/views/account_move_view.xml
+++ b/account_comment_template/views/account_move_view.xml
@@ -7,27 +7,9 @@
       <field name="arch" type="xml">
 
         <xpath expr="/form/sheet/notebook" position="inside">
-          <page string="Comments" name="comments">
-            <p
-                        style="margin-top: 10px;"
-                    >The comments will be displayed on the printed document. You can load a predefined template, write your own text or load a template and then modify it only for this document.</p>
-            <group string="Top Comments">
-              <field
-                            name="comment_template1_id"
-                            string="Load a template"
-                            context="{'default_position': 'before_lines'}"
-                        />
-              <field name="note1" nolabel="1" colspan="2" />
-            </group>
-            <group string="Bottom Comments">
-              <field
-                            name="comment_template2_id"
-                            string="Load a template"
-                            context="{'default_position': 'after_lines'}"
-                        />
-              <field name="note2" nolabel="1" colspan="2" />
-            </group>
-          </page>
+            <page string="Comments" name="comments">
+                <field name="comment_template_ids" />
+            </page>
         </xpath>
 
       </field>

--- a/account_comment_template/views/report_invoice.xml
+++ b/account_comment_template/views/report_invoice.xml
@@ -5,17 +5,24 @@
         id="report_invoice_document_comments"
         inherit_id="account.report_invoice_document"
     >
-
-        <xpath expr="//table[@name='invoice_line_table']" position="before">
-            <p t-if="o.note1">
-                <span t-field="o.note1" />
-            </p>
+        <xpath expr="//div[@id='informations']" position="after">
+            <t
+                t-set="before_comment_template_ids"
+                t-value="o.comment_template_ids.filtered(lambda x: x.position == 'before_lines')"
+            />
+            <t t-foreach="before_comment_template_ids" t-as="comment_template_id">
+                <div t-raw="comment_template_id.text" />
+            </t>
         </xpath>
 
         <xpath expr="//div[@id='qrcode']" position="before">
-            <p t-if="o.note2">
-                <span t-field="o.note2" />
-            </p>
+            <t
+                t-set="after_comment_template_ids"
+                t-value="o.comment_template_ids.filtered(lambda x: x.position == 'after_lines')"
+            />
+            <t t-foreach="after_comment_template_ids" t-as="comment_template_id">
+                <div t-raw="comment_template_id.text" />
+            </t>
         </xpath>
 
     </template>


### PR DESCRIPTION
Include changes from 13.0 to standardize both versions:

- Migration to v13: https://github.com/OCA/account-invoice-reporting/pull/174 + https://github.com/OCA/sale-reporting/pull/105#discussion_r632752570

Locked by:
- [x] https://github.com/OCA/reporting-engine/pull/500
- [x] https://github.com/OCA/reporting-engine/pull/509

Lock:
- [x] `sale_comment_template` https://github.com/OCA/sale-reporting/pull/113

Please @joao-p-marques and @pedrobaeza can you review it?

@Tecnativa TT29138