### PR TITLE
[13.0][IMP] account_invoice_comment_template: Add domain to action_account_invoice_comment_template view

### DIFF
--- a/account_invoice_comment_template/views/base_comment_template_view.xml
+++ b/account_invoice_comment_template/views/base_comment_template_view.xml
@@ -5,6 +5,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.comment.template</field>
         <field name="view_mode">tree,form</field>
+        <field name="domain">[('model_ids.model', '=', 'account.move')]</field>
         <field
             name="context"
             eval="{'default_model_ids': [(4, ref('account.model_account_move'))]}"


### PR DESCRIPTION
According to https://github.com/OCA/sale-reporting/pull/105#discussion_r632747477, it's necessary to add domain to `action_account_invoice_comment_template` view.

Please @joao-p-marques and @pedrobaeza can you review it?

I will apply it in 14.0 (https://github.com/OCA/account-invoice-reporting/pull/194).