### PR TITLE
[13.0][FIX] account_invoice_comment_template: Remove unnecessary line (in 14.0 it's an error)

### DIFF
--- a/account_invoice_comment_template/tests/test_account_invoice_report.py
+++ b/account_invoice_comment_template/tests/test_account_invoice_report.py
@@ -58,7 +58,6 @@ class TestAccountInvoiceReport(TransactionCase):
         )
 
     def test_comments_in_invoice_report(self):
-        self.invoice._compute_comment_template_ids()
         res = (
             self.env["ir.actions.report"]
             ._get_report_from_name("account.report_invoice")
@@ -68,7 +67,6 @@ class TestAccountInvoiceReport(TransactionCase):
         self.assertRegexpMatches(str(res[0]), self.after_comment.text)
 
     def test_comments_in_invoice(self):
-        self.partner.property_comment_template_id = self.after_comment.id
         move_form = self._create_invoice()
         new_invoice = move_form.save()
         new_invoice._compute_comment_template_ids()


### PR DESCRIPTION
Remove unnecessary line (in 14.0 it's an error). Included in https://github.com/OCA/account-invoice-reporting/pull/194

Please @joao-p-marques and @pedrobaeza can you review it?

Locked by: 
- [x] `base_comment_template` https://github.com/OCA/reporting-engine/pull/512

@Tecnativa TT29138