### PR TITLE
[14.0][FIX] account_invoice_report_grouped_by_picking: Remove priority and change position=replace in report_invoice.xml to prevent errors

### DIFF
--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template
-        id="report_invoice_document"
-        inherit_id="account.report_invoice_document"
-        priority="99"
-    >
-        <xpath expr="//t[contains(@t-foreach, 'lines')]/t[3]" position="replace">
-
-    </xpath>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
+        <xpath expr="//t[contains(@t-foreach, 'lines')]/t[3]" position="attributes">
+            <attribute name="t-if">False</attribute>
+        </xpath>
         <xpath expr="//tbody[hasclass('invoice_tbody')]" position="inside">
             <t t-set="subtotal" t-value="0.0" />
             <t t-set="lines_grouped" t-value="o.lines_grouped_by_picking()" />


### PR DESCRIPTION
Remote priority and change position=replace in report_invoice.xml to prevent errors.

According to https://github.com/OCA/account-invoice-reporting/pull/194#issuecomment-848506918 it's a good idea apply these change although in PR related is not necessary.

Locked by:
- [x] `account_comment_template` https://github.com/OCA/account-invoice-reporting/pull/194

Please @joao-p-marques and @pedrobaeza can you review it?