### PR TITLE
[13.0][ADD] account_invoice_line_sale_line_position

### DIFF
--- a/account_invoice_line_sale_line_position/__init__.py
+++ b/account_invoice_line_sale_line_position/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_line_sale_line_position/__manifest__.py
+++ b/account_invoice_line_sale_line_position/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Account Invoice Line Sale Line Position",
+    "summary": "Adds the related sale line position on invoice line.",
+    "version": "13.0.1.0.0",
+    "category": "Sale",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/account-invoice-reporting",
+    "depends": ["sale_order_line_position"],
+    "data": ["views/account_move_views.xml", "report/invoice_report.xml"],
+    "installable": True,
+}

--- a/account_invoice_line_sale_line_position/models/__init__.py
+++ b/account_invoice_line_sale_line_position/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice

--- a/account_invoice_line_sale_line_position/models/account_invoice.py
+++ b/account_invoice_line_sale_line_position/models/account_invoice.py
@@ -1,0 +1,34 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    has_order_position = fields.Boolean(compute="_compute_has_order_position")
+
+    @api.depends("invoice_line_ids.position_formatted")
+    def _compute_has_order_position(self):
+        for record in self:
+            record.has_order_position = any(
+                record.invoice_line_ids.mapped("position_formatted")
+            )
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    position_formatted = fields.Char(compute="_compute_position_formatted")
+
+    @api.depends("sale_line_ids.position")
+    def _compute_position_formatted(self):
+        for record in self:
+            if record.display_type:
+                record.position_formatted = ""
+                continue
+            values = [
+                val for val in record.sale_line_ids.mapped("position_formatted") if val
+            ]
+            record.position_formatted = "/".join(values)

--- a/account_invoice_line_sale_line_position/readme/CONTRIBUTORS.rst
+++ b/account_invoice_line_sale_line_position/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/account_invoice_line_sale_line_position/readme/DESCRIPTION.rst
+++ b/account_invoice_line_sale_line_position/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module is build on top of the module `sale_order_line_position`.
+
+It adds (if any) the sale line position on the invoice line.
+There can be multiple positions for one invoicing line. And they are
+added to the report.

--- a/account_invoice_line_sale_line_position/report/invoice_report.xml
+++ b/account_invoice_line_sale_line_position/report/invoice_report.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
+        <xpath expr="//table/thead/tr/th[@name='th_description']" position="before">
+            <th t-if="o.has_order_position" class="text-left">Pos</th>
+        </xpath>
+        <xpath
+            expr="//table/tbody[hasclass('invoice_tbody')]//td[@name='account_invoice_line_name']"
+            position="before"
+        >
+            <td t-if="o.has_order_position">
+                <span t-field="line.position_formatted" />
+            </td>
+        </xpath>
+    </template>
+</odoo>

--- a/account_invoice_line_sale_line_position/tests/__init__.py
+++ b/account_invoice_line_sale_line_position/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_invoice_line_sale_line_position

--- a/account_invoice_line_sale_line_position/tests/test_account_invoice_line_sale_line_position.py
+++ b/account_invoice_line_sale_line_position/tests/test_account_invoice_line_sale_line_position.py
@@ -1,0 +1,51 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SingleTransactionCase
+
+
+class TestAccountInvoiceLineSaleLinePosition(SingleTransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner = cls.env.ref("base.res_partner_12")
+        cls.product = cls.env.ref("product.product_product_9")
+        cls.order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "name": cls.product.name,
+                            "product_uom_qty": 4.0,
+                            "price_unit": 123.0,
+                            "qty_delivered": 4.0,
+                        },
+                    ),
+                    (0, 0, {"name": "section", "display_type": "line_section"},),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "name": cls.product.name,
+                            "product_uom_qty": 1.0,
+                            "price_unit": 0.0,
+                            "qty_delivered": 1.0,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.order.action_confirm()
+        cls.order._force_lines_to_invoice_policy_order()
+
+    def test_invoice_position(self):
+        """Check positions are retrieved from sale line."""
+        self.invoice = self.order._create_invoices()
+        self.assertEqual(self.invoice.invoice_line_ids[0].position_formatted, "001")
+        self.assertEqual(self.invoice.invoice_line_ids[1].position_formatted, "")
+        self.assertEqual(self.invoice.invoice_line_ids[2].position_formatted, "002")

--- a/account_invoice_line_sale_line_position/views/account_move_views.xml
+++ b/account_invoice_line_sale_line_position/views/account_move_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="model">account.move</field>
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='invoice_line_ids']//field[@name='product_id']"
+                position="before"
+            >
+                <field name="position_formatted" string="Pos" optional="hide" />
+            </xpath>
+            <xpath
+                expr="//field[@name='invoice_line_ids']//form//field[@name='product_id']"
+                position="before"
+            >
+                <field name="position_formatted" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -2,3 +2,4 @@
 # Add a repository url and branch if you need a forked version
 stock-logistics-workflow
 reporting-engine
+sale-reporting

--- a/setup/account_invoice_line_sale_line_position/odoo/addons/account_invoice_line_sale_line_position
+++ b/setup/account_invoice_line_sale_line_position/odoo/addons/account_invoice_line_sale_line_position
@@ -1,0 +1,1 @@
+../../../../account_invoice_line_sale_line_position

--- a/setup/account_invoice_line_sale_line_position/setup.py
+++ b/setup/account_invoice_line_sale_line_position/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Depends on 

- [x] https://github.com/OCA/sale-reporting/pull/114

This module is build on top of the module `sale_order_line_position`,
from `sale_reporting`.

It adds (if any) the sale line position on the invoice line.
There can be multiple position for one invoicing line. And they are
added to the report.