### PR TITLE
[FIX] partner_time_to_pay: add reconciled status to check payment status

### DIFF
--- a/partner_time_to_pay/models/res_partner.py
+++ b/partner_time_to_pay/models/res_partner.py
@@ -84,7 +84,7 @@ class ResPartner(models.Model):
     def _get_invoice_payment(self, payment_ids, date_due):
         days_for_latest_payment = 0
         for payment in payment_ids:
-            if payment.state == 'posted':
+            if payment.state in ['posted', 'reconciled']:
                 days_for_this_payment = (
                     fields.Date.from_string(payment.payment_date) -
                     date_due).days


### PR DESCRIPTION
Before PR:
-----------

- In calculation, it only bring posted payment.
- It ignore reconciled payment.

![Screenshot from 2021-06-03 16-16-04](https://user-images.githubusercontent.com/14229503/123340789-a67fa980-d501-11eb-9c2b-eb79e5ccc695.png)


After PR:
-----------

- In calculation, It will bring posted as well as reconciled payment.