### PR TITLE
[IMP] base_comment_template : allow user to set both(after and before lines) comment templates

### DIFF
--- a/base_comment_template/models/res_partner.py
+++ b/base_comment_template/models/res_partner.py
@@ -11,9 +11,14 @@ class ResPartner(models.Model):
         string='Conditions template',
         company_dependent=True,
     )
+    property_comment_after_template_id = fields.Many2one(
+        comodel_name="base.comment.template",
+        string="After Lines Comment template",
+        company_dependent=True,
+    )
 
     @api.model
     def _commercial_fields(self):
         res = super(ResPartner, self)._commercial_fields()
-        res += ['property_comment_template_id']
+        res += ['property_comment_template_id', 'property_comment_after_template_id']
         return res

--- a/base_comment_template/tests/test_base_comment_template.py
+++ b/base_comment_template/tests/test_base_comment_template.py
@@ -6,17 +6,25 @@ class TestResPartner(TransactionCase):
 
     def setUp(self):
         super(TestResPartner, self).setUp()
-        self.template_id = self.env['base.comment.template'].create({
+        self.before_template_id = self.env['base.comment.template'].create({
             'name': 'Comment before lines',
             'position': 'before_lines',
             'text': 'Text before lines',
+        })
+        self.after_template_id = self.env["base.comment.template"].create({
+            'name': 'Comment after lines',
+            'position': 'after_lines',
+            'text': 'Text after lines',
         })
 
     def test_commercial_partner_fields(self):
         # Azure Interior
         partner_id = self.env.ref('base.res_partner_12')
-        partner_id.property_comment_template_id = self.template_id.id
+        partner_id.property_comment_template_id = self.before_template_id.id
+        partner_id.property_comment_after_template_id = self.after_template_id.id
         # Test childs propagation of commercial partner field
         for child_id in partner_id.child_ids:
             self.assertEqual(
-                child_id.property_comment_template_id, self.template_id)
+                child_id.property_comment_template_id, self.before_template_id)
+            self.assertEqual(
+                child_id.property_comment_after_template_id, self.after_template_id)

--- a/base_comment_template/views/comment_view.xml
+++ b/base_comment_template/views/comment_view.xml
@@ -31,7 +31,7 @@
                     </div>
                     <group>
                         <group>
-                            <field name="position" widget="radio" invisible="context.get('default_position')"/>
+                            <field name="position" widget="radio" readonly="context.get('default_position')"/>
                         </group>
                         <group>
                             <field name="company_id" groups="base.group_multi_company"/>

--- a/base_comment_template/views/res_partner.xml
+++ b/base_comment_template/views/res_partner.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <group name="sale" position="inside">
                 <field name="property_comment_template_id" attrs="{'invisible': ['|',('customer', '=', False), ('is_company', '=', False), ('parent_id', '!=', False)]}"/>
+                <field name="property_comment_after_template_id" string="After Lines Comment Template" context="{'default_position': 'after_lines'}" domain="[('position', '=', 'after_lines')]" attrs="{'invisible': ['|',('customer', '=', False), ('is_company', '=', False), ('parent_id', '!=', False)]}"/>
             </group>
         </field>
     </record>


### PR DESCRIPTION
On Partner, the user can set both types of comment templates.
1. a new field `property_comment_after_template_id` is added, to set only "After Line" comment template
2. Later, the Existing field `property_comment_template_id`, will require domain and context, so the user can set only the "Before Line" comment template. (It is not included in this PR, to keep existing logic)
3. Later it will require to adapt change to depended modules like "account_invoice_comment_template", "sale_comment_template" etc