### PR TITLE
[12.0][FIX] account_invoice_report_due_list: refund invoices and header

### DIFF
--- a/account_invoice_report_due_list/models/account_invoice.py
+++ b/account_invoice_report_due_list/models/account_invoice.py
@@ -34,7 +34,7 @@ class AccountInvoice(models.Model):
         self.ensure_one()
         due_list = []
         if self.move_id:
-            if self.type in ['in_invoice', 'out_refund']:
+            if self.type in ['in_invoice', 'in_refund']:
                 due_move_line_ids = self.move_id.line_ids.filtered(
                     lambda ml: ml.account_id.internal_type == 'payable'
                 )

--- a/account_invoice_report_due_list/views/report_invoice.xml
+++ b/account_invoice_report_due_list/views/report_invoice.xml
@@ -5,7 +5,7 @@
 
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//p[@t-field='o.date_due']/.." position="attributes">
-            <attribute name="t-att-class">'hidden'</attribute>
+            <attribute name="class" add="d-none" separator=" " />
         </xpath>
         <xpath expr="//span[@t-field='o.payment_term_id.note']" position="after">
             <t t-set="due_list" t-value="o.get_multi_due_list()"/>


### PR DESCRIPTION
- The due list wasn't shown in refunds
- The due date wasn't meant to be shown in the header although it was
due to a wrong class setting.

cc @Tecnativa TT31048

please review @carlosdauden @pedrobaeza 