### PR TITLE
[13.0][FIX] account_invoice_report_due_list: refund invoices and header

### DIFF
--- a/account_invoice_report_due_list/models/account_move.py
+++ b/account_invoice_report_due_list/models/account_move.py
@@ -28,7 +28,7 @@ class AccountMove(models.Model):
     def get_multi_due_list(self):
         self.ensure_one()
         due_list = []
-        if self.type in ["in_invoice", "out_refund"]:
+        if self.type in ["in_invoice", "in_refund"]:
             due_move_line_ids = self.line_ids.filtered(
                 lambda ml: ml.account_id.internal_type == "payable" and ml.date_maturity
             )

--- a/account_invoice_report_due_list/views/report_invoice.xml
+++ b/account_invoice_report_due_list/views/report_invoice.xml
@@ -5,7 +5,7 @@
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//p[@t-field='o.invoice_date_due']/.." position="attributes">
-            <attribute name="t-att-class">'hidden'</attribute>
+            <attribute name="class" add="d-none" separator=" " />
         </xpath>
         <xpath
             expr="//span[@t-field='o.invoice_payment_term_id.note']"


### PR DESCRIPTION
Forward port of
- https://github.com/OCA/account-invoice-reporting/pull/202

Fixes:

- The due list wasn't shown in refunds
- The due date wasn't meant to be shown in the header although it was
due to a wrong class setting.

cc @Tecnativa TT31048

please review @carlosdauden @pedrobaeza 