### PR TITLE
[14.0][FIX] account_invoice_report_due_list: refund invoices header

### DIFF
--- a/account_invoice_report_due_list/views/report_invoice.xml
+++ b/account_invoice_report_due_list/views/report_invoice.xml
@@ -5,7 +5,7 @@
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//p[@t-field='o.invoice_date_due']/.." position="attributes">
-            <attribute name="t-att-class">'hidden'</attribute>
+            <attribute name="class" add="d-none" separator=" " />
         </xpath>
         <xpath
             expr="//span[@t-field='o.invoice_payment_term_id.note']"


### PR DESCRIPTION
Forward port of
- https://github.com/OCA/account-invoice-reporting/pull/202

It just applies this fix as the other one was already covered:

- The due date wasn't meant to be shown in the header although it was
due to a wrong class setting.

cc @Tecnativa TT31048

please review @carlosdauden @pedrobaeza 