### PR TITLE
[13.0][FIX] account_invoice_report_grouped_by_picking: Use Form in tests to avoid crash test

### DIFF
--- a/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
+++ b/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
@@ -6,7 +6,7 @@
 from lxml import html
 
 from odoo import fields
-from odoo.tests.common import SavepointCase
+from odoo.tests.common import Form, SavepointCase
 
 
 class TestAccountInvoiceGroupPicking(SavepointCase):
@@ -58,6 +58,16 @@ class TestAccountInvoiceGroupPicking(SavepointCase):
             }
         )
 
+    def get_return_picking_wizard(self, picking):
+        stock_return_picking_form = Form(
+            self.env["stock.return.picking"].with_context(
+                active_ids=picking.ids,
+                active_id=picking.ids[0],
+                active_model="stock.picking",
+            )
+        )
+        return stock_return_picking_form.save()
+
     def test_account_invoice_group_picking(self):
         # confirm quotation
         self.sale.action_confirm()
@@ -107,12 +117,7 @@ class TestAccountInvoiceGroupPicking(SavepointCase):
         picking.action_done()
         self.sale._create_invoices()
         # Return one picking from sale1
-        wiz_return = (
-            self.env["stock.return.picking"]
-            .with_context(active_model="stock.picking", active_id=picking.id,)
-            .create({})
-        )
-        wiz_return._onchange_picking_id()
+        wiz_return = self.get_return_picking_wizard(picking)
         res = wiz_return.create_returns()
         picking_return = self.env["stock.picking"].browse(res["res_id"])
         picking_return.move_line_ids.write({"qty_done": 1})


### PR DESCRIPTION
Crash test due to this Odoo commit
https://github.com/OCA/OCB/commit/8ca10a8f39c6e6b8647a695aa543f008f01ba034
The wizard lines have the field uom_id related to move.product_uom and readonly=False, if you call directly to wiz.onchage_picking_id a write in stock move is executed.

cc @Tecnativa
ping @carlosdauden @CarlosRoca13 

