### PR TITLE
[OU-IMP] account_invoice_comment_template: Improving migration script

### DIFF
--- a/account_invoice_comment_template/migrations/13.0.1.0.0/post-migration.py
+++ b/account_invoice_comment_template/migrations/13.0.1.0.0/post-migration.py
@@ -6,6 +6,11 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.logged_query(
+        env.cr, "DROP TABLE account_move_base_comment_template_rel"
+    )
+    Move = env["account.move"]
+    Move._fields["comment_template_ids"].update_db(Move, False)
+    openupgrade.logged_query(
         env.cr,
         """
         INSERT INTO account_move_base_comment_template_rel

--- a/account_invoice_comment_template/migrations/13.0.1.0.0/pre-migration.py
+++ b/account_invoice_comment_template/migrations/13.0.1.0.0/pre-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # We need to create the table in order to prevent the computation. It will be
+    # correctly generated later.
+    openupgrade.logged_query(
+        env.cr,
+        """
+        CREATE TABLE "account_move_base_comment_template_rel" ("temp" INTEGER )
+        """,
+    )


### PR DESCRIPTION
Without this change it took 15 minutes to process 600.000 invoices. Now it should take less than one minute. Similar approach to purchase from OpenUpgrade:

https://github.com/OCA/OpenUpgrade/blob/13.0/addons/purchase/migrations/13.0.1.2/pre-migration.py#L36
https://github.com/OCA/OpenUpgrade/blob/13.0/addons/purchase/migrations/13.0.1.2/post-migration.py#L32