### PR TITLE
[13.0][IMP] account_invoice_report_due_list: Add compute_sudo=True to avoid errors

### DIFF
--- a/account_invoice_report_due_list/models/account_move.py
+++ b/account_invoice_report_due_list/models/account_move.py
@@ -9,7 +9,9 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     multi_due = fields.Boolean(string="Multiple date due", compute="_compute_multi_due")
-    multi_date_due = fields.Char(string="Due Dates", compute="_compute_multi_date_due")
+    multi_date_due = fields.Char(
+        string="Due Dates", compute="_compute_multi_date_due", compute_sudo=True
+    )
 
     @api.depends("invoice_payment_term_id")
     def _compute_multi_due(self):


### PR DESCRIPTION
Add `compute_sudo=True` to avoid errors if the user does not have access to the account.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT30686