### PR TITLE
[13] add partner id name when parent id

### DIFF
--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -46,6 +46,12 @@
                                 t-options="{'widget': 'date'}"
                             />
                             <span t-field="picking.name" />
+                            <t t-if="len(lines_grouped) &gt; 1">
+                                <span>&amp;nbsp;</span>
+                                <t t-if="picking.partner_id.parent_id">
+                                    <span t-field="picking.partner_id.name"/>
+                                </t>
+                            </t>                            
                         </strong>
                     </td>
                 </tr>


### PR DESCRIPTION
When you do a group invoice and the partner has a parent now this info is shown. Is usefull as example if you have a customer with 5 shipping addres and you invoice him to 1 invoice contact.