### PR TITLE
[13.0][FIX] account_invoice_report_grouped_by_picking: Duplicated invoice lines

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -36,8 +36,17 @@ class AccountMove(models.Model):
         picking_dict = OrderedDict()
         lines_dict = OrderedDict()
         # Not change sign if the credit note has been created from reverse move option
-        # instead of sale order invoicing process after picking reverse transfer
-        sign = -1.0 if self.type == "out_refund" and not self.reversed_entry_id else 1.0
+        # and it has the same pickings related than the reversed invoice instead of sale
+        # order invoicing process after picking reverse transfer
+        sign = (
+            -1.0
+            if self.type == "out_refund"
+            and (
+                not self.reversed_entry_id
+                or self.reversed_entry_id.picking_ids != self.picking_ids
+            )
+            else 1.0
+        )
         # Let's get first a correspondance between pickings and sales order
         so_dict = {x.sale_id: x for x in self.picking_ids if x.sale_id}
         # Now group by picking by direct link or via same SO as picking's one


### PR DESCRIPTION
After the patch on stock_picking_invoice_link to link the refund moves to the return pickings created before the refund. This module shows on the picking duplicated lines.

With this patch the sign is correctly set and this duplication does not exist.

Before this patch:
![imagen](https://user-images.githubusercontent.com/35952655/196137073-b45e3a8f-6c91-4b8f-ad39-4873f009f02b.png)

After this patch:
![imagen](https://user-images.githubusercontent.com/35952655/196137285-d12ac1b5-0fd1-43ef-b098-26919820b3a3.png)

cc @Tecnativa TT39916

please @pedrobaeza @sergio-teruel review this