### PR TITLE
[14.0][FIX] account_invoice_report_grouped_by_picking: Duplicated invoice lines

### DIFF
--- a/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
+++ b/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
@@ -151,3 +151,125 @@ class TestAccountInvoiceGroupPicking(SavepointCase):
         refund_invoice = self.env["account.move"].browse(reversal["res_id"])
         groups = refund_invoice.lines_grouped_by_picking()
         self.assertEqual(len(groups), 2)
+
+    def test_account_invoice_group_picking_refund(self):
+        # confirm quotation
+        self.sale.action_confirm()
+        # deliver lines2
+        picking = self.sale.picking_ids[:1]
+        picking.action_confirm()
+        picking.move_line_ids.write({"qty_done": 1})
+        picking._action_done()
+        # invoice sales
+        invoice = self.sale._create_invoices()
+        invoice._post()
+        # Test directly grouping method
+        # invoice = self.env["account.move"].browse(inv_id)
+        groups = invoice.lines_grouped_by_picking()
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(groups[0]["picking"], groups[1]["picking"])
+        # Test report
+        content = html.document_fromstring(
+            self.env.ref("account.account_invoices")._render_qweb_html(invoice.id)[0]
+        )
+        tbody = content.xpath("//tbody[@class='invoice_tbody']")
+        tbody = [html.tostring(line, encoding="utf-8").strip() for line in tbody][
+            0
+        ].decode()
+        # information about sales is printed
+        self.assertEqual(tbody.count(self.sale.name), 1)
+        # information about pickings is printed
+        self.assertTrue(picking.name in tbody)
+        # Return picking
+        wiz_return = self.get_return_picking_wizard(picking)
+        res = wiz_return.create_returns()
+        picking_return = self.env["stock.picking"].browse(res["res_id"])
+        picking_return.move_line_ids.write({"qty_done": 1})
+        picking_return._action_done()
+        # Refund invoice
+        wiz_invoice_refund = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create({"refund_method": "cancel", "reason": "test"})
+        )
+        wiz_invoice_refund.reverse_moves()
+        new_invoice = self.sale.invoice_ids.filtered(
+            lambda i: i.move_type == "out_refund"
+        )
+        # Test directly grouping method
+        # invoice = self.env["account.move"].browse(inv_id)
+        groups = new_invoice.lines_grouped_by_picking()
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(groups[0]["picking"], groups[1]["picking"])
+        # Test report
+        content = html.document_fromstring(
+            self.env.ref("account.account_invoices")._render_qweb_html(new_invoice.id)[
+                0
+            ]
+        )
+        tbody = content.xpath("//tbody[@class='invoice_tbody']")
+        tbody = [html.tostring(line, encoding="utf-8").strip() for line in tbody][
+            0
+        ].decode()
+        # information about sales is printed
+        self.assertEqual(tbody.count(self.sale.name), 1)
+        # information about pickings is printed
+        self.assertTrue(picking_return.name in tbody)
+
+    def test_account_invoice_group_picking_refund_without_return(self):
+        # confirm quotation
+        self.sale.action_confirm()
+        # deliver lines2
+        picking = self.sale.picking_ids[:1]
+        picking.action_confirm()
+        picking.move_line_ids.write({"qty_done": 1})
+        picking._action_done()
+        # invoice sales
+        invoice = self.sale._create_invoices()
+        invoice._post()
+        # Test directly grouping method
+        # invoice = self.env["account.move"].browse(inv_id)
+        groups = invoice.lines_grouped_by_picking()
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(groups[0]["picking"], groups[1]["picking"])
+        # Test report
+        content = html.document_fromstring(
+            self.env.ref("account.account_invoices")._render_qweb_html(invoice.id)[0]
+        )
+        tbody = content.xpath("//tbody[@class='invoice_tbody']")
+        tbody = [html.tostring(line, encoding="utf-8").strip() for line in tbody][
+            0
+        ].decode()
+        # information about sales is printed
+        self.assertEqual(tbody.count(self.sale.name), 1)
+        # information about pickings is printed
+        self.assertTrue(picking.name in tbody)
+        # Refund invoice
+        wiz_invoice_refund = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create({"refund_method": "cancel", "reason": "test"})
+        )
+        wiz_invoice_refund.reverse_moves()
+        new_invoice = self.sale.invoice_ids.filtered(
+            lambda i: i.move_type == "out_refund"
+        )
+        # Test directly grouping method
+        # invoice = self.env["account.move"].browse(inv_id)
+        groups = new_invoice.lines_grouped_by_picking()
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(groups[0]["picking"], groups[1]["picking"])
+        # Test report
+        content = html.document_fromstring(
+            self.env.ref("account.account_invoices")._render_qweb_html(new_invoice.id)[
+                0
+            ]
+        )
+        tbody = content.xpath("//tbody[@class='invoice_tbody']")
+        tbody = [html.tostring(line, encoding="utf-8").strip() for line in tbody][
+            0
+        ].decode()
+        # information about sales is printed
+        self.assertEqual(tbody.count(self.sale.name), 1)
+        # information about pickings is printed
+        self.assertTrue(picking.name in tbody)


### PR DESCRIPTION
After the patch on stock_picking_invoice_link to link the refund moves to the return pickings created before the refund. This module shows on the picking duplicated lines.

With this patch the sign is correctly set and this duplication does not exist.

FW-PORT of https://github.com/OCA/account-invoice-reporting/pull/241

@Tecnativa TT39916 

please @sergio-teruel @victoralmau review this