### PR TITLE
[13.0][FIX] account_invoice_report_grouped_by_picking: refund invoice report

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -15,7 +15,10 @@ class AccountMove(models.Model):
     @api.model
     def _sort_grouped_lines(self, lines_dic):
         return sorted(
-            lines_dic, key=lambda x: (x["picking"].date, x["picking"].date_done)
+            lines_dic,
+            key=lambda x: (
+                (x["picking"].date, x["picking"].date_done or x["picking"].date)
+            ),
         )
 
     def _get_signed_quantity_done(self, invoice_line, move, sign):


### PR DESCRIPTION
Consider pending pickings that are linked to the invoice.

cc @Tecnativa TT40412

please review @sergio-teruel @carlosdauden 