### PR TITLE
[15.0][IMP] account_invoice_report_grouped_by_picking: Show section and notes

### DIFF
--- a/account_invoice_report_grouped_by_picking/README.rst
+++ b/account_invoice_report_grouped_by_picking/README.rst
@@ -49,14 +49,6 @@ Usage
 #. Invoice report will group invoice lines and show information about sales
    and pickings in every group.
 
-Known issues / Roadmap
-======================
-
-* As a result of the grouping by pickings, we don't support notes and descriptions.
-* Anyways, an invoice with no pickings should be printed as usual. The problem is
-  that in the current state of the report, a heavy refactoring is needed to be able to
-  fallback to the regular behavior in such case.
-
 Bug Tracker
 ===========
 

--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -59,6 +59,8 @@ class AccountMove(models.Model):
             for move in line.move_line_ids:
                 key = (move.picking_id, line)
                 picking_dict.setdefault(key, 0)
+                if move.location_id.usage == "customer":
+                    has_returned_qty = True
                 qty = self._get_signed_quantity_done(line, move, sign)
                 picking_dict[key] += qty
                 remaining_qty -= qty

--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -2,7 +2,7 @@
 # Copyright 2018 Tecnativa - David Vidal
 # Copyright 2018-2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
+import datetime
 from collections import OrderedDict
 
 from odoo import api, models
@@ -14,10 +14,14 @@ class AccountMove(models.Model):
 
     @api.model
     def _sort_grouped_lines(self, lines_dic):
+        min_date = datetime.datetime.min
         return sorted(
             lines_dic,
             key=lambda x: (
-                (x["picking"].date, x["picking"].date_done or x["picking"].date)
+                (
+                    x["picking"].date or min_date,
+                    x["picking"].date_done or x["picking"].date or min_date,
+                )
             ),
         )
 

--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -32,12 +32,23 @@ class AccountMove(models.Model):
             qty = move.quantity_done * sign
         return qty
 
+    def _process_section_note_lines_grouped(
+        self, previous_section, previous_note, lines_dic, pick_order=None
+    ):
+        key_section = (pick_order, previous_section) if pick_order else previous_section
+        if previous_section and key_section not in lines_dic:
+            lines_dic[key_section] = 0.0
+        key_note = (pick_order, previous_note) if pick_order else previous_note
+        if previous_note and key_note not in lines_dic:
+            lines_dic[key_note] = 0.0
+
     def lines_grouped_by_picking(self):
         """This prepares a data structure for printing the invoice report
         grouped by pickings."""
         self.ensure_one()
         picking_dict = OrderedDict()
         lines_dict = OrderedDict()
+        picking_obj = self.env["stock.picking"]
         # Not change sign if the credit note has been created from reverse move option
         # and it has the same pickings related than the reversed invoice instead of sale
         # order invoicing process after picking reverse transfer
@@ -53,11 +64,23 @@ class AccountMove(models.Model):
         # Let's get first a correspondance between pickings and sales order
         so_dict = {x.sale_id: x for x in self.picking_ids if x.sale_id}
         # Now group by picking by direct link or via same SO as picking's one
-        for line in self.invoice_line_ids.filtered(lambda x: not x.display_type):
+        previous_section = previous_note = False
+        for line in self.invoice_line_ids.sorted(
+            lambda ln: (-ln.sequence, ln.date, ln.move_name, -ln.id), reverse=True
+        ):
+            if line.display_type == "line_section":
+                previous_section = line
+                continue
+            if line.display_type == "line_note":
+                previous_note = line
+                continue
             has_returned_qty = False
             remaining_qty = line.quantity
             for move in line.move_line_ids:
                 key = (move.picking_id, line)
+                self._process_section_note_lines_grouped(
+                    previous_section, previous_note, picking_dict, move.picking_id
+                )
                 picking_dict.setdefault(key, 0)
                 if move.location_id.usage == "customer":
                     has_returned_qty = True
@@ -68,12 +91,18 @@ class AccountMove(models.Model):
                 for so_line in line.sale_line_ids:
                     if so_dict.get(so_line.order_id):
                         key = (so_dict[so_line.order_id], line)
+                        self._process_section_note_lines_grouped(
+                            previous_section,
+                            previous_note,
+                            picking_dict,
+                            so_dict[so_line.order_id],
+                        )
                         picking_dict.setdefault(key, 0)
                         qty = so_line.product_uom_qty
                         picking_dict[key] += qty
                         remaining_qty -= qty
             elif not line.move_line_ids and not line.sale_line_ids:
-                key = (self.env["stock.picking"], line)
+                key = (picking_obj, line)
                 picking_dict.setdefault(key, 0)
                 qty = line.quantity
                 picking_dict[key] += qty
@@ -88,9 +117,12 @@ class AccountMove(models.Model):
                 remaining_qty,
                 precision_rounding=line.product_id.uom_id.rounding or 0.01,
             ):
+                self._process_section_note_lines_grouped(
+                    previous_section, previous_note, lines_dict
+                )
                 lines_dict[line] = remaining_qty
         no_picking = [
-            {"picking": False, "line": key, "quantity": value}
+            {"picking": picking_obj, "line": key, "quantity": value}
             for key, value in lines_dict.items()
         ]
         with_picking = [

--- a/account_invoice_report_grouped_by_picking/readme/ROADMAP.rst
+++ b/account_invoice_report_grouped_by_picking/readme/ROADMAP.rst
@@ -1,4 +1,0 @@
-* As a result of the grouping by pickings, we don't support notes and descriptions.
-* Anyways, an invoice with no pickings should be printed as usual. The problem is
-  that in the current state of the report, a heavy refactoring is needed to be able to
-  fallback to the regular behavior in such case.

--- a/account_invoice_report_grouped_by_picking/static/description/index.html
+++ b/account_invoice_report_grouped_by_picking/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Account Invoice Grouped by Picking</title>
 <style type="text/css">
 
@@ -378,12 +378,11 @@ picking.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -400,17 +399,8 @@ orders.</li>
 and pickings in every group.</li>
 </ol>
 </div>
-<div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
-<ul class="simple">
-<li>As a result of the grouping by pickings, we don’t support notes and descriptions.</li>
-<li>Anyways, an invoice with no pickings should be printed as usual. The problem is
-that in the current state of the report, a heavy refactoring is needed to be able to
-fallback to the regular behavior in such case.</li>
-</ul>
-</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-invoice-reporting/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -418,15 +408,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id4">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Carlos Dauden</li>
@@ -444,7 +434,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -25,6 +25,10 @@
                 t-set="next_picking"
                 t-value="[lines_grouped[i + 1]['picking'] for i, x in enumerate(lines_grouped) if x == lines_group and i &lt; len(lines_grouped) - 1] or [False]"
             />
+            <!-- Avoid to show original subtotal -->
+            <t t-set="line_last" t-value="False" />
+            <t t-set="line_index" t-value="0" />
+
             <t t-if="picking != last_picking">
                 <t t-set="last_picking" t-value="picking" />
                 <tr t-if="picking">
@@ -64,14 +68,20 @@
         </xpath>
         <xpath expr="//td/span[@t-field='line.price_subtotal']" position="before">
             <t
-                t-if="lines_group['quantity'] != l.quantity"
-                id="picking_subtotal"
-                groups="!account.group_show_line_subtotals_tax_included"
-            >
+                t-set="line_subtotal"
+                t-value="l.price_subtotal"
+                groups="account.group_show_line_subtotals_tax_excluded"
+            />
+            <t
+                t-set="line_subtotal"
+                t-value="l.price_total"
+                groups="account.group_show_line_subtotals_tax_included"
+            />
+            <t t-if="lines_group['quantity'] != l.quantity" id="picking_subtotal">
                 <!-- Compute subtotal for that picking with discounts -->
                 <t
                     t-set="line_picking_subtotal"
-                    t-value="l.quantity and lines_group['quantity'] * (l.price_subtotal / l.quantity) or 0.0"
+                    t-value="l.quantity and lines_group['quantity'] * (line_subtotal / l.quantity) or 0.0"
                 />
                 <t
                     t-set="subtotal"
@@ -83,7 +93,7 @@
                 />
             </t>
             <t t-else="">
-                <t t-set="subtotal" t-value="(subtotal or 0.0) + l.price_subtotal" />
+                <t t-set="subtotal" t-value="(subtotal or 0.0) + line_subtotal" />
             </t>
         </xpath>
         <xpath expr="//td/span[@t-field='line.price_subtotal']" position="attributes">
@@ -107,30 +117,6 @@
                 </td>
                 <t t-set="subtotal" t-value="0.0" />
             </tr>
-        </xpath>
-        <!-- Replicate logic if B2C prices-->
-        <xpath expr="//td/span[@t-field='line.price_total']" position="before">
-            <t
-                t-if="lines_group['quantity'] != l.quantity"
-                groups="account.group_show_line_subtotals_tax_included"
-            >
-                <!-- Compute subtotal for that picking with discounts -->
-                <t
-                    t-set="line_picking_subtotal"
-                    t-value="l.quantity and lines_group['quantity'] * (l.price_total / l.quantity) or 0.0"
-                />
-                <t
-                    t-set="subtotal"
-                    t-value="(subtotal or 0.0) + line_picking_subtotal"
-                />
-                <span
-                    t-esc="line_picking_subtotal"
-                    t-options='{"widget": "monetary", "display_currency": o.currency_id}'
-                />
-            </t>
-            <t t-else="">
-                <t t-set="subtotal" t-value="(subtotal or 0.0) + l.price_total" />
-            </t>
         </xpath>
         <xpath expr="//td/span[@t-field='line.price_total']" position="attributes">
             <attribute name="t-if">lines_group['quantity'] == l.quantity</attribute>

--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -26,6 +26,7 @@
                 t-value="[lines_grouped[i + 1]['picking'] for i, x in enumerate(lines_grouped) if x == lines_group and i &lt; len(lines_grouped) - 1] or [False]"
             />
             <t t-if="picking != last_picking">
+                <t t-set="last_picking" t-value="picking" />
                 <tr t-if="picking">
                     <td colspan="10">
                         <strong>
@@ -106,7 +107,6 @@
                 </td>
                 <t t-set="subtotal" t-value="0.0" />
             </tr>
-            <t t-set="last_picking" t-value="picking" />
         </xpath>
         <!-- Replicate logic if B2C prices-->
         <xpath expr="//td/span[@t-field='line.price_total']" position="before">


### PR DESCRIPTION
Recover has_returned_qty removed by this PR:
https://github.com/OCA/account-invoice-reporting/pull/224#pullrequestreview-1245316565
ping @extrememicro 

FW https://github.com/OCA/account-invoice-reporting/pull/258
- Compatibility with section and notes lines (display_type)
- Remove roadmap
- Fix last_picking position to avoid picking header repeat in first line.

@Tecnativa
ping @chienandalu  @sergio-teruel 