### PR TITLE
[15.0][UPD] Update account_comment_template_report_invoice.xml

### DIFF
--- a/account_comment_template/views/report_invoice.xml
+++ b/account_comment_template/views/report_invoice.xml
@@ -11,7 +11,7 @@
                 t-value="o.comment_template_ids.filtered(lambda x: x.position == 'before_lines')"
             />
             <t t-foreach="before_comment_template_ids" t-as="comment_template_id">
-                <div t-esc="comment_template_id.text" />
+                <div t-raw="o.render_comment(comment_template_id)" />
             </t>
         </xpath>
 
@@ -21,7 +21,7 @@
                 t-value="o.comment_template_ids.filtered(lambda x: x.position == 'after_lines')"
             />
             <t t-foreach="after_comment_template_ids" t-as="comment_template_id">
-                <div t-esc="comment_template_id.text" />
+                <div t-raw="o.render_comment(comment_template_id)" />
             </t>
         </xpath>
 


### PR DESCRIPTION
Rendering of template is wrong. the base-comment-template work on the mixin of mail. this feature allow the possibilities to add {{ object }} and interpret them directly by the render_comment() function. 

today, the template render the comment html directly and bypass the render function. 

this update will render the comment template with interpreted value. 

https://github.com/OCA/reporting-engine/blob/15.0/base_comment_template/README.rst