### PR TITLE
[15.0][FIX] partner_time_to_pay: Data is calculated with partner + partner.child_ids invoices

### DIFF
--- a/partner_time_to_pay/models/res_partner.py
+++ b/partner_time_to_pay/models/res_partner.py
@@ -39,10 +39,10 @@ class ResPartner(models.Model):
     def _compute_d2x(self):
         for partner in self:
             partner.d2r_ytd, partner.d2r_life = partner._compute_d2x_per_invoice_type(
-                partner.invoice_ids, {"out_invoice"}
+                (partner + partner.child_ids).invoice_ids, {"out_invoice"}
             )
             partner.d2p_ytd, partner.d2p_life = partner._compute_d2x_per_invoice_type(
-                partner.invoice_ids, {"in_invoice"}
+                (partner + partner.child_ids).invoice_ids, {"in_invoice"}
             )
 
     def _compute_d2x_per_invoice_type(self, invoices, invoice_types):

--- a/partner_time_to_pay/readme/DESCRIPTION.rst
+++ b/partner_time_to_pay/readme/DESCRIPTION.rst
@@ -1,2 +1,3 @@
 This module displays statistics related to the receivables and payables behavior of a partner on the *Sales & Purchases* tab of the partner form view.
-Also displays the full reconcile payment date on invoices
+Also displays the full reconcile payment date on invoices.
+Statistics on each contact corresponds to the partner and its child contacts.

--- a/partner_time_to_pay/tests/test_partner_time_to_pay.py
+++ b/partner_time_to_pay/tests/test_partner_time_to_pay.py
@@ -20,13 +20,14 @@ class TestPartnerTimeToPay(TransactionCase):
             {
                 "name": "Test Time to Pay Partner",
                 "is_company": True,
+                "child_ids": [(0, 0, {"name": "TTPP Contact", "type": "invoice"})],
             }
         )
         self.time_to_pay_days = 10
         product = self.env.ref("product.product_product_4")
         # Create invoice
         move_form = Form(am_model.with_context(default_move_type="out_invoice"))
-        move_form.partner_id = self.partner
+        move_form.partner_id = self.partner.child_ids[0]
         move_form.invoice_date = today
         with move_form.invoice_line_ids.new() as line_form:
             line_form.product_id = product
@@ -46,5 +47,7 @@ class TestPartnerTimeToPay(TransactionCase):
         ).action_create_payments()
 
     def test_partner_compute_d2x(self):
+        self.assertEqual(self.partner.child_ids[0].d2r_ytd, self.time_to_pay_days)
+        self.assertEqual(self.partner.child_ids[0].d2r_life, self.time_to_pay_days)
         self.assertEqual(self.partner.d2r_ytd, self.time_to_pay_days)
         self.assertEqual(self.partner.d2r_life, self.time_to_pay_days)


### PR DESCRIPTION
The data is calculated using the contact and its children, so in each contact contact the aggregated data can be consulted.

Before there was no way to get what the statistics were at the Company level because the number of invoices was not in any field and a true proportion could not be made.
The data exclusively from the father and the children did not make sense because normally the information that is going to be used later (to provide information to investors, calculate a better payment term, etc.) requires knowing the data at the Company level in general (and perhaps for each Contact separately).

Now you have a vision of how the Company pays in general and how each of its children pays specifically.

MT-2393 @moduon @rafaelbn @max3903 