### PR TITLE
[13.0][FIX] account_invoice_report_grouped_by_picking: sold service refund

### DIFF
--- a/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
+++ b/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
@@ -27,6 +27,13 @@ class TestAccountInvoiceGroupPicking(SavepointCase):
                 "invoice_policy": "order",
             }
         )
+        cls.service2 = cls.env["product.product"].create(
+            {
+                "name": "Test service product 2",
+                "type": "service",
+                "invoice_policy": "order",
+            }
+        )
         cls.partner = cls.env["res.partner"].create({"name": "Partner for test"})
         cls.sale = cls.env["sale.order"].create(
             {
@@ -40,6 +47,35 @@ class TestAccountInvoiceGroupPicking(SavepointCase):
                             "product_id": cls.product.id,
                             "product_uom_qty": 2,
                             "product_uom": cls.product.uom_id.id,
+                            "price_unit": 100.0,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": cls.service.name,
+                            "product_id": cls.service.id,
+                            "product_uom_qty": 3,
+                            "product_uom": cls.service.uom_id.id,
+                            "price_unit": 50.0,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.sale2 = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": cls.service2.name,
+                            "product_id": cls.service2.id,
+                            "product_uom_qty": 2,
+                            "product_uom": cls.service2.uom_id.id,
                             "price_unit": 100.0,
                         },
                     ),
@@ -266,3 +302,39 @@ class TestAccountInvoiceGroupPicking(SavepointCase):
         self.assertEqual(tbody.count(self.sale.name), 1)
         # information about pickings is printed
         self.assertTrue(picking.name in tbody)
+
+    def test_account_invoice_group_picking_service_sale_reports_check(self):
+        self.sale2.action_confirm()
+        # invoice sales
+        invoice = self.sale2._create_invoices()
+        invoice.post()
+        # Test report
+        content = html.document_fromstring(
+            self.env.ref("account.account_invoices").render_qweb_html(invoice.id)[0]
+        )
+        tbody = content.xpath("//tbody[@class='invoice_tbody']")
+        tbody = [html.tostring(line, encoding="utf-8").strip() for line in tbody][
+            0
+        ].decode()
+        # check if service line is in report
+        self.assertTrue(self.sale2.order_line[0].name in tbody)
+        self.assertTrue(self.sale2.order_line[1].name in tbody)
+        # Refund invoice
+        wiz_invoice_refund = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create({"refund_method": "cancel", "reason": "test"})
+        )
+        wiz_invoice_refund.reverse_moves()
+        new_invoice = self.sale2.invoice_ids.filtered(lambda i: i.type == "out_refund")
+        # Test report
+        content = html.document_fromstring(
+            self.env.ref("account.account_invoices").render_qweb_html(new_invoice.id)[0]
+        )
+        tbody = content.xpath("//tbody[@class='invoice_tbody']")
+        tbody = [html.tostring(line, encoding="utf-8").strip() for line in tbody][
+            0
+        ].decode()
+        # check if service line is in report
+        self.assertTrue(self.sale2.order_line[0].name in tbody)
+        self.assertTrue(self.sale2.order_line[1].name in tbody)


### PR DESCRIPTION
If we're trying to make a refund of a service that had a link to a sale line those lines weren't ever returned.

cc @Tecnativa TT44067

please review @carlosdauden 