### PR TITLE
[16.0][FIX] account_invoice_report_payment_info: compute should be multi

### DIFF
--- a/account_invoice_report_payment_info/models/account_invoice.py
+++ b/account_invoice_report_payment_info/models/account_invoice.py
@@ -4,21 +4,22 @@
 from odoo import models
 
 
-class AccountInvoice(models.Model):
+class AccountMove(models.Model):
     _inherit = "account.move"
 
     def _compute_payments_widget_reconciled_info(self):
         res = super()._compute_payments_widget_reconciled_info()
-        if not res and not self.invoice_payments_widget:
-            return res
         info_pattern = (
             self.env["ir.config_parameter"]
             .sudo()
             .get_param("account_invoice_report_payment_info.info_pattern", default="")
         )
         Move = self.env["account.move"]
-        for payment_dict in self.invoice_payments_widget["content"]:
-            move = Move.browse(payment_dict["move_id"])
-            payment_dict["move_ref"] = move.ref
-            payment_dict["extra_info"] = info_pattern.format(**payment_dict)
+        for one in self:
+            if not res and not one.invoice_payments_widget:
+                continue
+            for payment_dict in one.invoice_payments_widget["content"]:
+                move = Move.browse(payment_dict["move_id"])
+                payment_dict["move_ref"] = move.ref
+                payment_dict["extra_info"] = info_pattern.format(**payment_dict)
         return res


### PR DESCRIPTION
super() is multi-record, like all compute methods.

This one should be too. Otherwise, it fails to integrate with `l10n_fr_account_vat_return` with `ValueError: Expected singleton: account.move(739, 737, 741, 735)`.

@moduon MT-1075