### PR TITLE
[14.0][FIX] account_invoice_report_grouped_by_picking: test compatibility

### DIFF
--- a/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
+++ b/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
@@ -101,8 +101,8 @@ class TestAccountInvoiceGroupPicking(SavepointCase):
             0
         ].decode()
         # information about sales is printed
-        self.assertEqual(tbody.count(self.sale.name), 1)
-        self.assertEqual(tbody.count(self.sale2.name), 1)
+        self.assertEqual(tbody.count(f"<span>{self.sale.name}</span>"), 1)
+        self.assertEqual(tbody.count(f"<span>{self.sale2.name}</span>"), 1)
         # information about pickings is printed
         self.assertTrue(self.sale.invoice_ids.picking_ids[:1].name in tbody)
         self.assertTrue(self.sale2.invoice_ids.picking_ids[:1].name in tbody)


### PR DESCRIPTION
The module `sale_order_line_sequence` adds a column to the invoice report with a sequence that could contain the name of the sales order when the lines belong to different orders. Let's make sure that we count only our row content.

cc @Tecnativa TT46702

please review @CarlosRoca13 @carlosdauden 