### PR TITLE
[14.0][IMP] account_invoice_report_grouped_by_picking: Show section and notes

### DIFF
--- a/account_invoice_report_grouped_by_picking/README.rst
+++ b/account_invoice_report_grouped_by_picking/README.rst
@@ -52,14 +52,6 @@ Usage
 #. Invoice report will group invoice lines and show information about sales
    and pickings in every group.
 
-Known issues / Roadmap
-======================
-
-* As a result of the grouping by pickings, we don't support notes and descriptions.
-* Anyways, an invoice with no pickings should be printed as usual. The problem is
-  that in the current state of the report, a heavy refactoring is needed to be able to
-  fallback to the regular behavior in such case.
-
 Bug Tracker
 ===========
 
@@ -92,6 +84,10 @@ Contributors
 * `Studio73 <https://www.studio73.es>`__:
 
   * Ioan Galan <ioan@studio73.es>
+
+* `Sygel <https://www.sygel.es>`__:
+
+  * Manuel Regidor <manuel.regidor@sygel.es>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -16,15 +16,17 @@ class AccountMove(models.Model):
     @api.model
     def _sort_grouped_lines(self, lines_dic):
         min_date = datetime.datetime.min
-        return sorted(
+        dictionary = sorted(
             lines_dic,
             key=lambda x: (
                 (
                     x["picking"].date or min_date,
                     x["picking"].date_done or x["picking"].date or min_date,
+                    x.get("is_last_section_notes", False),
                 )
             ),
         )
+        return dictionary
 
     def _get_signed_quantity_done(self, invoice_line, move, sign):
         """Hook method. Usage example:
@@ -70,15 +72,33 @@ class AccountMove(models.Model):
         so_dict = {x.sale_id: x for x in self.picking_ids if x.sale_id}
         # Now group by picking by direct link or via same SO as picking's one
         previous_section = previous_note = False
+        last_section_notes = []
         for line in self.invoice_line_ids.sorted(
             lambda ln: (-ln.sequence, ln.date, ln.move_name, -ln.id), reverse=True
         ):
             if line.display_type == "line_section":
                 previous_section = line
+                last_section_notes.append(
+                    {
+                        "picking": picking_obj,
+                        "line": line,
+                        "qty": 0.0,
+                        "is_last_section_notes": True,
+                    }
+                )
                 continue
             if line.display_type == "line_note":
                 previous_note = line
+                last_section_notes.append(
+                    {
+                        "picking": picking_obj,
+                        "line": line,
+                        "qty": 0.0,
+                        "is_last_section_notes": True,
+                    }
+                )
                 continue
+            last_section_notes = []
             has_returned_qty = False
             remaining_qty = line.quantity
             for move in line.move_line_ids:
@@ -135,4 +155,7 @@ class AccountMove(models.Model):
             {"picking": key[0], "line": key[1], "quantity": value}
             for key, value in picking_dict.items()
         ]
-        return no_picking + self._sort_grouped_lines(with_picking)
+        lines_to_sort = with_picking
+        if last_section_notes:
+            lines_to_sort += last_section_notes
+        return no_picking + self._sort_grouped_lines(lines_to_sort)

--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -1,11 +1,12 @@
-# Copyright 2017 Tecnativa - Carlos Dauden
+# Copyright 2017-2023 Tecnativa - Carlos Dauden
 # Copyright 2018 Tecnativa - David Vidal
 # Copyright 2018-2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import datetime
 from collections import OrderedDict
 
-from odoo import api, fields, models
+from odoo import api, models
 from odoo.tools import float_is_zero
 
 
@@ -14,11 +15,14 @@ class AccountMove(models.Model):
 
     @api.model
     def _sort_grouped_lines(self, lines_dic):
+        min_date = datetime.datetime.min
         return sorted(
             lines_dic,
             key=lambda x: (
-                x["picking"].date or fields.Datetime.now(),
-                x["picking"].date_done or fields.Datetime.now(),
+                (
+                    x["picking"].date or min_date,
+                    x["picking"].date_done or x["picking"].date or min_date,
+                )
             ),
         )
 
@@ -33,12 +37,23 @@ class AccountMove(models.Model):
             qty = move.quantity_done * sign
         return qty
 
+    def _process_section_note_lines_grouped(
+        self, previous_section, previous_note, lines_dic, pick_order=None
+    ):
+        key_section = (pick_order, previous_section) if pick_order else previous_section
+        if previous_section and key_section not in lines_dic:
+            lines_dic[key_section] = 0.0
+        key_note = (pick_order, previous_note) if pick_order else previous_note
+        if previous_note and key_note not in lines_dic:
+            lines_dic[key_note] = 0.0
+
     def lines_grouped_by_picking(self):
         """This prepares a data structure for printing the invoice report
         grouped by pickings."""
         self.ensure_one()
         picking_dict = OrderedDict()
         lines_dict = OrderedDict()
+        picking_obj = self.env["stock.picking"]
         # Not change sign if the credit note has been created from reverse move option
         # and it has the same pickings related than the reversed invoice instead of sale
         # order invoicing process after picking reverse transfer
@@ -54,11 +69,23 @@ class AccountMove(models.Model):
         # Let's get first a correspondance between pickings and sales order
         so_dict = {x.sale_id: x for x in self.picking_ids if x.sale_id}
         # Now group by picking by direct link or via same SO as picking's one
-        for line in self.invoice_line_ids.filtered(lambda x: not x.display_type):
+        previous_section = previous_note = False
+        for line in self.invoice_line_ids.sorted(
+            lambda ln: (-ln.sequence, ln.date, ln.move_name, -ln.id), reverse=True
+        ):
+            if line.display_type == "line_section":
+                previous_section = line
+                continue
+            if line.display_type == "line_note":
+                previous_note = line
+                continue
             has_returned_qty = False
             remaining_qty = line.quantity
             for move in line.move_line_ids:
                 key = (move.picking_id, line)
+                self._process_section_note_lines_grouped(
+                    previous_section, previous_note, picking_dict, move.picking_id
+                )
                 picking_dict.setdefault(key, 0)
                 qty = self._get_signed_quantity_done(line, move, sign)
                 picking_dict[key] += qty
@@ -67,12 +94,21 @@ class AccountMove(models.Model):
                 for so_line in line.sale_line_ids:
                     if so_dict.get(so_line.order_id):
                         key = (so_dict[so_line.order_id], line)
+                        self._process_section_note_lines_grouped(
+                            previous_section,
+                            previous_note,
+                            picking_dict,
+                            so_dict[so_line.order_id],
+                        )
                         picking_dict.setdefault(key, 0)
                         qty = so_line.product_uom_qty
                         picking_dict[key] += qty
                         remaining_qty -= qty
             elif not line.move_line_ids and not line.sale_line_ids:
-                key = (self.env["stock.picking"], line)
+                key = (picking_obj, line)
+                self._process_section_note_lines_grouped(
+                    previous_section, previous_note, lines_dict
+                )
                 picking_dict.setdefault(key, 0)
                 qty = line.quantity
                 picking_dict[key] += qty
@@ -87,9 +123,12 @@ class AccountMove(models.Model):
                 remaining_qty,
                 precision_rounding=line.product_id.uom_id.rounding or 0.01,
             ):
+                self._process_section_note_lines_grouped(
+                    previous_section, previous_note, lines_dict
+                )
                 lines_dict[line] = remaining_qty
         no_picking = [
-            {"picking": False, "line": key, "quantity": value}
+            {"picking": picking_obj, "line": key, "quantity": value}
             for key, value in lines_dict.items()
         ]
         with_picking = [

--- a/account_invoice_report_grouped_by_picking/readme/CONTRIBUTORS.rst
+++ b/account_invoice_report_grouped_by_picking/readme/CONTRIBUTORS.rst
@@ -9,3 +9,7 @@
 * `Studio73 <https://www.studio73.es>`__:
 
   * Ioan Galan <ioan@studio73.es>
+
+* `Sygel <https://www.sygel.es>`__:
+
+  * Manuel Regidor <manuel.regidor@sygel.es>

--- a/account_invoice_report_grouped_by_picking/readme/ROADMAP.rst
+++ b/account_invoice_report_grouped_by_picking/readme/ROADMAP.rst
@@ -1,4 +1,0 @@
-* As a result of the grouping by pickings, we don't support notes and descriptions.
-* Anyways, an invoice with no pickings should be printed as usual. The problem is
-  that in the current state of the report, a heavy refactoring is needed to be able to
-  fallback to the regular behavior in such case.

--- a/account_invoice_report_grouped_by_picking/static/description/index.html
+++ b/account_invoice_report_grouped_by_picking/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -380,12 +379,11 @@ picking.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -402,17 +400,8 @@ orders.</li>
 and pickings in every group.</li>
 </ol>
 </div>
-<div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
-<ul class="simple">
-<li>As a result of the grouping by pickings, we don’t support notes and descriptions.</li>
-<li>Anyways, an invoice with no pickings should be printed as usual. The problem is
-that in the current state of the report, a heavy refactoring is needed to be able to
-fallback to the regular behavior in such case.</li>
-</ul>
-</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-invoice-reporting/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -420,15 +409,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Carlos Dauden</li>
@@ -442,10 +431,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Ioan Galan &lt;<a class="reference external" href="mailto:ioan&#64;studio73.es">ioan&#64;studio73.es</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.sygel.es">Sygel</a>:<ul>
+<li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
-        <xpath expr="//t[contains(@t-foreach, 'lines')]/t[3]" position="attributes">
-            <attribute name="t-if">False</attribute>
-        </xpath>
-        <xpath expr="//tbody[hasclass('invoice_tbody')]" position="inside">
-            <t t-set="subtotal" t-value="0.0" />
+    <template
+        id="report_invoice_document"
+        inherit_id="account.report_invoice_document"
+        priority="99"
+    >
+        <xpath expr="//t[contains(@t-set, 'o')]" position="after">
             <t t-set="lines_grouped" t-value="o.lines_grouped_by_picking()" />
         </xpath>
+        <xpath expr="//t[contains(@t-foreach, 'lines')]/t[3]" position="replace" />
+        <xpath expr="//tbody[hasclass('invoice_tbody')]" position="inside">
+            <t t-set="subtotal" t-value="0.0" />
+        </xpath>
         <xpath expr="//t[contains(@t-foreach, 'lines')]" position="attributes">
-            <attribute name="t-foreach">o.lines_grouped_by_picking()</attribute>
+            <attribute name="t-foreach">lines_grouped</attribute>
             <attribute name="t-as">lines_group</attribute>
         </xpath>
         <!-- Appends before 'current_subtotal' compute -->
@@ -20,12 +24,16 @@
             <t t-set="l" t-value="lines_group['line']" />
             <t t-set="line" t-value="lines_group['line']" />
             <t t-set="picking" t-value="lines_group['picking']" />
-            <t t-set="lines_grouped" t-value="o.lines_grouped_by_picking()" />
             <t
                 t-set="next_picking"
                 t-value="[lines_grouped[i + 1]['picking'] for i, x in enumerate(lines_grouped) if x == lines_group and i &lt; len(lines_grouped) - 1] or [False]"
             />
+            <!-- Avoid to show original subtotal -->
+            <t t-set="line_last" t-value="False" />
+            <t t-set="line_index" t-value="0" />
+
             <t t-if="picking != last_picking">
+                <t t-set="last_picking" t-value="picking" />
                 <tr t-if="picking">
                     <td colspan="10">
                         <strong>
@@ -63,14 +71,20 @@
         </xpath>
         <xpath expr="//td/span[@t-field='line.price_subtotal']" position="before">
             <t
-                t-if="lines_group['quantity'] != l.quantity"
-                id="picking_subtotal"
-                groups="!account.group_show_line_subtotals_tax_included"
-            >
+                t-set="line_subtotal"
+                t-value="l.price_subtotal"
+                groups="account.group_show_line_subtotals_tax_excluded"
+            />
+            <t
+                t-set="line_subtotal"
+                t-value="l.price_total"
+                groups="account.group_show_line_subtotals_tax_included"
+            />
+            <t t-if="lines_group['quantity'] != l.quantity" id="picking_subtotal">
                 <!-- Compute subtotal for that picking with discounts -->
                 <t
                     t-set="line_picking_subtotal"
-                    t-value="l.quantity and lines_group['quantity'] * (l.price_subtotal / l.quantity) or 0.0"
+                    t-value="l.quantity and lines_group['quantity'] * (line_subtotal / l.quantity) or 0.0"
                 />
                 <t
                     t-set="subtotal"
@@ -82,7 +96,7 @@
                 />
             </t>
             <t t-else="">
-                <t t-set="subtotal" t-value="(subtotal or 0.0) + l.price_subtotal" />
+                <t t-set="subtotal" t-value="(subtotal or 0.0) + line_subtotal" />
             </t>
         </xpath>
         <xpath expr="//td/span[@t-field='line.price_subtotal']" position="attributes">
@@ -93,7 +107,7 @@
         </xpath>
         <!-- Append subtotal row after invoice line row-->
         <xpath
-            expr="//t[@t-foreach='o.lines_grouped_by_picking()']//td[hasclass('o_price_total')]"
+            expr="//t[@t-foreach='lines_grouped']//td[hasclass('o_price_total')]"
             position="after"
         >
             <tr t-if="picking != next_picking[0]">
@@ -106,31 +120,6 @@
                 </td>
                 <t t-set="subtotal" t-value="0.0" />
             </tr>
-            <t t-set="last_picking" t-value="picking" />
-        </xpath>
-        <!-- Replicate logic if B2C prices-->
-        <xpath expr="//td/span[@t-field='line.price_total']" position="before">
-            <t
-                t-if="lines_group['quantity'] != l.quantity"
-                groups="account.group_show_line_subtotals_tax_included"
-            >
-                <!-- Compute subtotal for that picking with discounts -->
-                <t
-                    t-set="line_picking_subtotal"
-                    t-value="l.quantity and lines_group['quantity'] * (l.price_total / l.quantity) or 0.0"
-                />
-                <t
-                    t-set="subtotal"
-                    t-value="(subtotal or 0.0) + line_picking_subtotal"
-                />
-                <span
-                    t-esc="line_picking_subtotal"
-                    t-options='{"widget": "monetary", "display_currency": o.currency_id}'
-                />
-            </t>
-            <t t-else="">
-                <t t-set="subtotal" t-value="(subtotal or 0.0) + l.price_total" />
-            </t>
         </xpath>
         <xpath expr="//td/span[@t-field='line.price_total']" position="attributes">
             <attribute name="t-if">lines_group['quantity'] == l.quantity</attribute>

--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -25,13 +25,16 @@
             <t t-set="line" t-value="lines_group['line']" />
             <t t-set="picking" t-value="lines_group['picking']" />
             <t
+                t-set="next_line"
+                t-value="[lines_grouped[i + 1] for i, x in enumerate(lines_grouped) if x == lines_group and i &lt; len(lines_grouped) - 1] or [False]"
+            />
+            <t
                 t-set="next_picking"
                 t-value="[lines_grouped[i + 1]['picking'] for i, x in enumerate(lines_grouped) if x == lines_group and i &lt; len(lines_grouped) - 1] or [False]"
             />
             <!-- Avoid to show original subtotal -->
             <t t-set="line_last" t-value="False" />
             <t t-set="line_index" t-value="0" />
-
             <t t-if="picking != last_picking">
                 <t t-set="last_picking" t-value="picking" />
                 <tr t-if="picking">
@@ -111,6 +114,21 @@
             position="after"
         >
             <tr t-if="picking != next_picking[0]">
+                <td colspan="10" class="text-right">
+                    <strong>Subtotal: </strong>
+                    <strong
+                        t-esc="subtotal"
+                        t-options='{"widget": "monetary", "display_currency": o.currency_id}'
+                    />
+                </td>
+                <t t-set="subtotal" t-value="0.0" />
+            </tr>
+        </xpath>
+        <!-- Append subtotal after notes and sections at the end of the invoice-->
+        <xpath expr="//t[@name='account_invoice_line_accountable']/.." position="after">
+            <tr
+                t-if="lines_group.get('is_last_section_notes') and (not next_line or not next_line[0].get('is_last_section_notes')) and subtotal"
+            >
                 <td colspan="10" class="text-right">
                     <strong>Subtotal: </strong>
                     <strong


### PR DESCRIPTION
From https://github.com/OCA/account-invoice-reporting/pull/258

Commit 15363c54813bb186df4b9a5b572ff17f68b2dbaa applies changes in tests in module account_invoice_report_grouped_by_picking_sale_mrp because of method _sort_grouped_lines in account.move in module  account_invoice_report_grouped_by_picking. When this method is called in test_account_invoice_group_picking in module account_invoice_report_grouped_by_picking_sale_mrp, it is suposed to get a list of picking in a certain order. However, as the creation and validation of pickings in the test is done so quickly, the fields date and date_done in the pickings are the same, so the funtion _sort_grouped_lines does no sorting and the test fails.

T-5666