### PR TITLE
[15.0][IMP] account_invoice_report_grouped_by_picking: Show notes/sections at the end of invoice

### DIFF
--- a/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
+++ b/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
@@ -387,3 +387,62 @@ class TestAccountInvoiceGroupPicking(TransactionCase):
         # check if service line is in report
         self.assertTrue(self.sale2.order_line[0].name in tbody)
         self.assertTrue(self.sale2.order_line[1].name in tbody)
+
+    def test_account_invoice_group_picking_note_section_end(self):
+        # confirm quotation
+        self.sale.action_confirm()
+        # deliver lines2
+        picking = self.sale.picking_ids[:1]
+        picking.action_confirm()
+        picking.move_line_ids.write({"qty_done": 1})
+        picking._action_done()
+        # invoice sales
+        invoice = self.sale._create_invoices()
+        groups = invoice.lines_grouped_by_picking()
+        self.assertEqual(len(groups), 2)
+        invoice.write(
+            {
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Note",
+                            "display_type": "line_note",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Section",
+                            "display_type": "line_section",
+                        },
+                    ),
+                ],
+            }
+        )
+        groups = invoice.lines_grouped_by_picking()
+        self.assertEqual(len(groups), 4)
+        self.assertTrue(groups[0].get("is_last_section_notes", False))
+        self.assertTrue(groups[1].get("is_last_section_notes", False))
+        self.assertFalse(groups[2].get("is_last_section_notes", False))
+        self.assertFalse(groups[3].get("is_last_section_notes", False))
+        invoice.invoice_line_ids.filtered(
+            lambda a: a.product_id == self.product
+        ).with_context(check_move_validity=False).write({"quantity": 3})
+        invoice.invoice_line_ids.filtered(
+            lambda a: a.product_id == self.service
+        ).with_context(check_move_validity=False).write({"quantity": 4})
+        groups = invoice.lines_grouped_by_picking()
+        self.assertEqual(len(groups), 6)
+        self.assertFalse(groups[0].get("is_last_section_notes", False))
+        self.assertFalse(groups[0]["picking"])
+        self.assertFalse(groups[1].get("is_last_section_notes", False))
+        self.assertFalse(groups[1]["picking"])
+        self.assertTrue(groups[2].get("is_last_section_notes", False))
+        self.assertTrue(groups[3].get("is_last_section_notes", False))
+        self.assertFalse(groups[4].get("is_last_section_notes", False))
+        self.assertTrue(groups[4]["picking"])
+        self.assertFalse(groups[5].get("is_last_section_notes", False))
+        self.assertTrue(groups[5]["picking"])

--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -23,6 +23,10 @@
             <t t-set="line" t-value="lines_group['line']" />
             <t t-set="picking" t-value="lines_group['picking']" />
             <t
+                t-set="next_line"
+                t-value="[lines_grouped[i + 1] for i, x in enumerate(lines_grouped) if x == lines_group and i &lt; len(lines_grouped) - 1] or [False]"
+            />
+            <t
                 t-set="next_picking"
                 t-value="[lines_grouped[i + 1]['picking'] for i, x in enumerate(lines_grouped) if x == lines_group and i &lt; len(lines_grouped) - 1] or [False]"
             />
@@ -109,6 +113,21 @@
             position="after"
         >
             <tr t-if="picking != next_picking[0]">
+                <td colspan="10" class="text-right">
+                    <strong>Subtotal: </strong>
+                    <strong
+                        t-esc="subtotal"
+                        t-options='{"widget": "monetary", "display_currency": o.currency_id}'
+                    />
+                </td>
+                <t t-set="subtotal" t-value="0.0" />
+            </tr>
+        </xpath>
+        <!-- Append subtotal after notes and sections at the end of the invoice-->
+        <xpath expr="//t[@name='account_invoice_line_accountable']/.." position="after">
+            <tr
+                t-if="lines_group.get('is_last_section_notes') and (not next_line or not next_line[0].get('is_last_section_notes')) and subtotal"
+            >
                 <td colspan="10" class="text-right">
                     <strong>Subtotal: </strong>
                     <strong

--- a/account_invoice_report_grouped_by_picking_sale_mrp/tests/test_report_grouped_sale_mrp.py
+++ b/account_invoice_report_grouped_by_picking_sale_mrp/tests/test_report_grouped_sale_mrp.py
@@ -1,6 +1,10 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import datetime, timedelta
+
+from freezegun import freeze_time
+
 from odoo.tests import Form, TransactionCase
 
 
@@ -63,15 +67,19 @@ class TestReportGroupedSaleMrp(TransactionCase):
 
     def test_account_invoice_group_picking(self):
         # confirm quotation
-        self.sale_order.action_confirm()
-        self.assertEqual(len(self.sale_order.picking_ids), 1)
-        picking_1 = self.sale_order.picking_ids
-        self.assertEqual(len(picking_1.move_lines), 4)
-        self.assertEqual(self.sale_order.order_line.move_ids, picking_1.move_lines)
-        # deliver the sold kit_2 components
-        picking_1.action_confirm()
-        picking_1.mapped("move_lines").write({"quantity_done": 2})
-        picking_1._action_done()
+        # with freeze_time is used so the account.move lines_grouped_by_picking
+        # method sorts lines as expected
+        with freeze_time(datetime.now() - timedelta(seconds=5)):
+            self.sale_order.action_confirm()
+            self.assertEqual(len(self.sale_order.picking_ids), 1)
+            picking_1 = self.sale_order.picking_ids
+            self.assertEqual(len(picking_1.move_lines), 4)
+            self.assertEqual(self.sale_order.order_line.move_ids, picking_1.move_lines)
+            # deliver the sold kit_2 components
+            picking_1.action_confirm()
+            picking_1.mapped("move_lines").write({"quantity_done": 2})
+            picking_1._action_done()
+
         # Change the existing order line qty from 2 to 3 and deliver
         # the new kit_2
         with Form(self.sale_order) as sale_form:


### PR DESCRIPTION
Based on commits https://github.com/OCA/account-invoice-reporting/pull/308/commits/a1e2958f937afc28a3cba7bd19124296f9f9cfb5 and https://github.com/OCA/account-invoice-reporting/pull/308/commits/3ca3f836ae2497c81d78eaba6ece12be6208e3d8

T-5952