### PR TITLE
[14.0][FIX] account_invoice_report_grouped_by_picking: reports of credit notes without lines.

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -135,7 +135,7 @@ class AccountMove(models.Model):
                 remaining_qty -= qty
             # To avoid to print duplicate lines because the invoice is a refund
             # without returned goods to refund.
-            if self.move_type == "out_refund" and not has_returned_qty:
+            if self.move_type == "out_refund" and not has_returned_qty and picking_dict:
                 remaining_qty = 0.0
                 for key in picking_dict:
                     picking_dict[key] = abs(picking_dict[key])


### PR DESCRIPTION
There is an error in the reports of credit notes created before installing the account_invoice_report_grouped_by_picking module and its dependency stock_picking_invoice_link, as they are printed without lines.

To reproduce the error with the runboat:
1. Uninstall the stock_picking_invoice_link.
2. Create and confirm a sales order.
3. Validate the delivery note.
4. Create and confirm the invoice.
5. Create and confirm a credit note -> Print - > CORRECT:
![Captura desde 2024-04-17 12-24-59](https://github.com/OCA/account-invoice-reporting/assets/101106685/c8cf8dce-e862-4a96-8a74-6530b659109d)

6. Install the module account_invoice_report_grouped_by_picking.
7. Print the credit note generated in step 5. -> ERROR.
![Captura desde 2024-04-17 12-26-06](https://github.com/OCA/account-invoice-reporting/assets/101106685/30302352-c690-4039-a1f7-3ca347c171e1)


[I-5787]

