### PR TITLE
[15.0][FIX] account_invoice_report_grouped_by_picking: reports of credit notes without lines.

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -145,6 +145,7 @@ class AccountMove(models.Model):
                 and not has_returned_qty
                 and remaining_qty
                 and line.product_id.type != "service"
+                and picking_dict
             ):
                 remaining_qty = 0.0
                 for key in picking_dict:


### PR DESCRIPTION
Same fix as in PR https://github.com/OCA/account-invoice-reporting/pull/312


[I-5787]