### PR TITLE
[15.0][FIX] account_invoice_report_grouped_by_picking: Avoid crash on empty groups

### DIFF
--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -126,7 +126,7 @@
         <!-- Append subtotal after notes and sections at the end of the invoice-->
         <xpath expr="//t[@name='account_invoice_line_accountable']/.." position="after">
             <tr
-                t-if="lines_group.get('is_last_section_notes') and (not next_line or not next_line[0].get('is_last_section_notes')) and subtotal"
+                t-if="lines_group.get('is_last_section_notes') and (not next_line or (next_line[0] and not next_line[0].get('is_last_section_notes'))) and subtotal"
             >
                 <td colspan="10" class="text-right">
                     <strong>Subtotal: </strong>


### PR DESCRIPTION
- Create an invoice with one line without product
- Print
- You get the following error:

AttributeError: 'bool' object has no attribute 'get'

Error when render the template
AttributeError: 'bool' object has no attribute 'get' Template: account.report_invoice_document
Path: /t/t/div/table/tbody/t[4]/tr[2]
Node: <tr t-if="lines_group.get('is_last_section_notes') and (not next_line or not next_line[0].get('is_last_section_notes')) and subtotal"/>

@Tecnativa TT49057