### PR TITLE
[17.0][FIX] account_invoice_report_grouped_by_picking

### DIFF
--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -69,7 +69,6 @@
         </xpath>
         <xpath expr="//td/span[@t-field='line.price_subtotal']" position="before">
             <t t-set="line_subtotal" t-value="l.price_subtotal" />
-            <t t-set="line_subtotal" t-value="l.price_total" />
             <t t-if="lines_group['quantity'] != l.quantity" id="picking_subtotal">
                 <!-- Compute subtotal for that picking with discounts -->
                 <t


### PR DESCRIPTION
Fix subtotals with discount.

When you print an invoice with lines that have discounts and lines that do not:
 - The lines that have the discount appear without tax while the lines that do not have a discount appear with the tax.
![image](https://github.com/OCA/account-invoice-reporting/assets/124153097/dc2db7ae-0ea8-46be-a675-afbacd15b4f7)
