### PR TITLE
[14.0][FIX] account_invoice_report_grouped_by_picking.

### DIFF
--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -127,7 +127,7 @@
         <!-- Append subtotal after notes and sections at the end of the invoice-->
         <xpath expr="//t[@name='account_invoice_line_accountable']/.." position="after">
             <tr
-                t-if="lines_group.get('is_last_section_notes') and (not next_line or not next_line[0].get('is_last_section_notes')) and subtotal"
+                t-if="lines_group.get('is_last_section_notes') and (not next_line or (next_line[0] and not next_line[0].get('is_last_section_notes'))) and subtotal"
             >
                 <td colspan="10" class="text-right">
                     <strong>Subtotal: </strong>


### PR DESCRIPTION
Hi, i found a error  when  i printed  some account.move report  without pickings and with note on line. 

Error:
Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo-server/odoo/addons/base/models/qweb.py", line 329, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_account_report_invoice_document_3446
  File "<template>", line 2, in body_call_content_3444
  File "<template>", line 1, in foreach_3399
AttributeError: 'bool' object has no attribute 'get'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo-server/addons/web/controllers/main.py", line 2107, in report_download
    response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
  File "/opt/odoo-server/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo-server/extra-addons/oca/reporting-engine/report_xlsx/controllers/main.py", line 18, in report_routes
    return super(ReportController, self).report_routes(
  File "/opt/odoo-server/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo-server/addons/web/controllers/main.py", line 2038, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(docids, data=data)[0]
  File "/opt/odoo-server/addons/account/models/ir_actions_report.py", line 54, in _render_qweb_pdf
    return super()._render_qweb_pdf(res_ids=res_ids, data=data)
  File "/opt/odoo-server/odoo/addons/base/models/ir_actions_report.py", line 896, in _render_qweb_pdf
    html = self_sudo.with_context(context)._render_qweb_html(res_ids, data=data)[0]
  File "/opt/odoo-server/extra-addons/oca/account-financial-reporting/account_financial_report/models/ir_actions_report.py", line 19, in _render_qweb_html
    return super(IrActionsReport, obj)._render_qweb_html(docids, data)
  File "/opt/odoo-server/odoo/addons/base/models/ir_actions_report.py", line 937, in _render_qweb_html
    return self._render_template(self.report_name, data), 'html'
  File "/opt/odoo-server/odoo/addons/base/models/ir_actions_report.py", line 672, in _render_template
    return view_obj._render_template(template, values)
  File "/opt/odoo-server/odoo/addons/base/models/ir_ui_view.py", line 1727, in _render_template
    return self.browse(self.get_view_id(template))._render(values, engine)
  File "/opt/odoo-server/addons/web_editor/models/ir_ui_view.py", line 28, in _render
    return super(IrUiView, self)._render(values=values, engine=engine, minimal_qcontext=minimal_qcontext)
  File "/opt/odoo-server/odoo/addons/base/models/ir_ui_view.py", line 1735, in _render
    return self.env[engine]._render(self.id, qcontext)
  File "/opt/odoo-server/odoo/addons/base/models/ir_qweb.py", line 55, in _render
    result = super(IrQWeb, self)._render(id_or_xml_id, values=values, **context)
  File "/opt/odoo-server/odoo/addons/base/models/qweb.py", line 254, in _render
    self.compile(template, options)(self, body.append, values or {})
  File "/opt/odoo-server/odoo/addons/base/models/qweb.py", line 331, in _compiled_fn
    raise e
  File "/opt/odoo-server/odoo/addons/base/models/qweb.py", line 329, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_account_report_invoice_with_payments_3361
  File "<template>", line 2, in body_call_content_3359
  File "<template>", line 3, in foreach_3358
  File "/opt/odoo-server/odoo/addons/base/models/qweb.py", line 336, in _compiled_fn
    raise QWebException("Error to render compiling AST", e, path, node and etree.tostring(node[0], encoding='unicode'), name)
odoo.addons.base.models.qweb.QWebException: 'bool' object has no attribute 'get'
Traceback (most recent call last):
  File "/opt/odoo-server/odoo/addons/base/models/qweb.py", line 329, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_account_report_invoice_document_3446
  File "<template>", line 2, in body_call_content_3444
  File "<template>", line 1, in foreach_3399
AttributeError: 'bool' object has no attribute 'get'

Error to render compiling AST
AttributeError: 'bool' object has no attribute 'get'
Template: account.report_invoice_document
Path: /t/t/div/table/tbody/t[3]/tr[2]
Node: <tr t-if="lines_group.get('is_last_section_notes') and (not next_line or not next_line[0].get('is_last_section_notes')) and subtotal">
                <td colspan="10" class="text-right">
                    <strong>Subtotal: </strong>
                    <strong t-esc="subtotal" t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: o.currency_id}"/>
                </td>
                <t t-set="subtotal" t-value="0.0"/>
            </tr>

Example of account.move object:
![image](https://github.com/OCA/account-invoice-reporting/assets/128601880/e2516e18-61ed-4ff8-bcf7-598483990856)

Summary the next_line variable can be a list with a False inside, you must check that the value of position 0 before using the .get() method, in this line  : ` <tr t-if="lines_group.get('is_last_section_notes') and (not next_line or not next_line[0].get('is_last_section_notes')) and subtotal">"`


