### PR TITLE
[14.0][FIX] account_invoice_report_grouped_by_picking: partial refund qty d…

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -135,10 +135,20 @@ class AccountMove(models.Model):
                 remaining_qty -= qty
             # To avoid to print duplicate lines because the invoice is a refund
             # without returned goods to refund.
-            if self.move_type == "out_refund" and not has_returned_qty and picking_dict:
-                remaining_qty = 0.0
+            if (
+                self.move_type == "out_refund"
+                and not has_returned_qty
+                and remaining_qty
+                and line.product_id.type != "service"
+                and picking_dict
+            ):
                 for key in picking_dict:
-                    picking_dict[key] = abs(picking_dict[key])
+                    # If remaining_qty is not zero, it means the quantity
+                    # refunded is more or less than the quantity delivered
+                    # so we need to add the difference to the total otherwise
+                    # the report will display an incorrect quantity.
+                    picking_dict[key] = abs(picking_dict[key]) + remaining_qty
+                remaining_qty = 0.0
             if not float_is_zero(
                 remaining_qty,
                 precision_rounding=line.product_id.uom_id.rounding or 0.01,


### PR DESCRIPTION
…isplayed

This small fix solve an issue when refunding invoices using the reverse move option.

Tested branches 14.0, 15.0, 16.0, 17.0
Steps to replicate it:

1. Create and confirm a sale with one line but multiple qty
2. Deliver the products
3. Invoice the sale
4. Use the "Add credit note" option on the invoice
5. Modify the refunded qty to a lower one
6. Print the refund, the quantity displayed is always the delivered one