### PR TITLE
[16.0][FIX] account_invoice_report_grouped_by_picking: Ensure exact search for tests instead of partial search

### DIFF
--- a/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
+++ b/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
@@ -125,8 +125,8 @@ class TestAccountInvoiceGroupPicking(TransactionCase):
             0
         ].decode()
         # information about sales is printed
-        self.assertEqual(tbody.count(self.sale.name), 1)
-        self.assertEqual(tbody.count(self.sale2.name), 1)
+        self.assertGreaterEqual(tbody.count(f"<span>{self.sale.name}</span>"), 1)
+        self.assertGreaterEqual(tbody.count(f"<span>{self.sale2.name}</span>"), 1)
         # information about pickings is printed
         self.assertTrue(self.sale.invoice_ids.picking_ids[:1].name in tbody)
         self.assertTrue(self.sale2.invoice_ids.picking_ids[:1].name in tbody)


### PR DESCRIPTION
When installed with other modules (e.g., sale_order_line_sequence), this commit makes the assertion more specific to avoid inconsistencies. sale_order_line_sequence adds a similar span (<span>S00001/1</span>), causing duplicate searches.

![image](https://github.com/user-attachments/assets/cef2d023-6441-4291-834a-f6adc9f3abf1)


before

![image](https://github.com/user-attachments/assets/5d03ae5a-a5f2-44d8-9d49-b038cdaa500f)
after, no error on test 

@tecnativa TT50196