### PR TITLE
17.0[FIX][account_invoice_bank_details]: the module is setting by default bank account from the company

### DIFF
--- a/account_invoice_bank_details/models/account_move.py
+++ b/account_invoice_bank_details/models/account_move.py
@@ -9,8 +9,10 @@ class AccountMove(models.Model):
 
     @api.depends("currency_id", "company_id.partner_id")
     def _compute_partner_bank_id(self):
+        # Override the method to set the first matching bank account in currency of
+        # the company. It is done only for customer invoices and refunds.
         for record in self:
-            if record.currency_id:
+            if record.currency_id and record.move_type in ["out_invoice", "out_refund"]:
                 # try to find bank account by currency
                 partner_bank = self.env["res.partner.bank"].search(
                     [
@@ -27,6 +29,5 @@ class AccountMove(models.Model):
                     )
 
                 record.partner_bank_id = partner_bank.id
-
             else:
-                return super()._compute_partner_bank_id
+                return super()._compute_partner_bank_id()

--- a/account_invoice_bank_details/readme/CONTRIBUTORS.md
+++ b/account_invoice_bank_details/readme/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 - [camptocamp](https://camptocamp.com):
 - Vincent Renaville \<<https://www.camptocamp.com>\>
+- Denis Leemann \<<https://www.camptocamp.com>\>
 - [Trobz](https://trobz.com):
 - Do Anh Duy \<<duyda@trobz.com>\>

--- a/account_invoice_bank_details/readme/DESCRIPTION.md
+++ b/account_invoice_bank_details/readme/DESCRIPTION.md
@@ -1,3 +1,5 @@
 This module allows you to select a default bank account based on the
 currency of the invoice. It will also display the bank details on the
-invoice
+invoice.
+
+Nota Bene: it is done on customer invoices/refund, not on vendor bills


### PR DESCRIPTION
### Previous behavior
All account.move where set with the bank account of the company
This lead to wrong computation on vendor bills/refund. As in this case we want to use the one from the vendor.

### New behavior
The computation of the company bank account with the correct currency is now computed only on customer invoices