### PR TITLE
[15.0][FIX] account_invoice_report_grouped_by_picking: Recover default precision_rounding missed in previous PR

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -129,7 +129,8 @@ class AccountMove(models.Model):
             # To avoid to print duplicate lines because the invoice is a refund
             # without returned goods to refund.
             remaining_qty = float_round(
-                remaining_qty, precision_rounding=line.product_id.uom_id.rounding
+                remaining_qty,
+                precision_rounding=line.product_id.uom_id.rounding or 0.01,
             )
             if (
                 self.move_type == "out_refund"


### PR DESCRIPTION
This is necessary when the invoice line does not have product.

FW-Port not needed because is OK in those versions

@Tecnativa TT51404

ping @sergio-teruel @CarlosRoca13 