### PR TITLE
[17.0][FIX] account_invoice_report_grouped_by_picking: Display subtotals instead of totals

### DIFF
--- a/account_invoice_report_grouped_by_picking/views/report_invoice.xml
+++ b/account_invoice_report_grouped_by_picking/views/report_invoice.xml
@@ -69,7 +69,6 @@
         </xpath>
         <xpath expr="//td/span[@t-field='line.price_subtotal']" position="before">
             <t t-set="line_subtotal" t-value="l.price_subtotal" />
-            <t t-set="line_subtotal" t-value="l.price_total" />
             <t t-if="lines_group['quantity'] != l.quantity" id="picking_subtotal">
                 <!-- Compute subtotal for that picking with discounts -->
                 <t


### PR DESCRIPTION
When the same invoice line is linked to multiple pickings, the calculation shows the total price instead of the subtotal. That's what I'm trying to fix here. Besides the amount that is shown in the original Odoo invoice report is the subtotal.

ping @carlosdauden @pedrobaeza 