### PR TITLE
[FIX] [16.0] account_invoice_report_product_sticker: Select which model are being requesting stickers

### DIFF
--- a/account_invoice_report_product_sticker/models/account_move.py
+++ b/account_invoice_report_product_sticker/models/account_move.py
@@ -44,8 +44,10 @@ class AccountMove(models.Model):
         for move in self:
             if not move.show_product_stickers:
                 continue
-
-            products = move.line_ids.product_id
-            stickers = products.get_product_stickers()
-            if stickers:
-                move.sticker_ids = stickers
+            move.sticker_ids = move.line_ids.product_id.get_product_stickers(
+                extra_domain=[
+                    "|",
+                    ("available_model_ids.model", "in", [self._name]),
+                    ("available_model_ids", "=", False),
+                ]
+            )


### PR DESCRIPTION
Update how it works to match the new arguments.

This PR needs to be merged first in order to work: https://github.com/OCA/product-attribute/pull/1893

MT-9075 @moduon @rafaelbn @yajo @fcvalgar @EmilioPascual please review if you want 😄 