### PR TITLE
[16.0][FIX] account_invoice_report_due_list: Post-install test + fallback to load CoA

### DIFF
--- a/account_invoice_report_due_list/tests/test_invoice_report_due_list.py
+++ b/account_invoice_report_due_list/tests/test_invoice_report_due_list.py
@@ -7,15 +7,25 @@ from datetime import timedelta
 import babel
 
 from odoo import fields
-from odoo.tests import common
+from odoo.tests import common, tagged
 from odoo.tests.common import Form
 from odoo.tools import posix_to_ldml, pycompat
 
 
+@tagged("post_install", "-at_install")
 class TestInvoiceReportDueList(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.account_tax = cls.env["account.tax"].create(
             {"name": "0%", "amount_type": "fixed", "type_tax_use": "sale", "amount": 0}
         )


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa