### PR TITLE
[18.0] [FIX] account_invoice_line_sale_line_position: compute position_formatted for all invoice lines

### DIFF
--- a/account_invoice_line_sale_line_position/models/account_invoice.py
+++ b/account_invoice_line_sale_line_position/models/account_invoice.py
@@ -25,11 +25,10 @@ class AccountMoveLine(models.Model):
     @api.depends("sale_line_ids.position")
     def _compute_position_formatted(self):
         for record in self:
-            if record.display_type:
+            if record.display_type != "product":
                 record.position_formatted = ""
                 continue
-        values = [
-            val for val in record.sale_line_ids.mapped("position_formatted") if val
-        ]
-
-        record.position_formatted = "/".join(values)
+            values = [
+                val for val in record.sale_line_ids.mapped("position_formatted") if val
+            ]
+            record.position_formatted = "/".join(values)


### PR DESCRIPTION
The purpose of this PR is to fix the module `account_invoice_line_sale_line_position`, 
which is currently not functional in Odoo 18.

As already mentioned by @nikolaszimmermann in issue #378 ,
invoice lines should correctly display the position from their related sale lines.
