### PR TITLE
[18.0][FIX] account_invoice_line_report: Make sure search view is empty

### DIFF
--- a/account_invoice_line_report/report/account_invoice_report_view.xml
+++ b/account_invoice_line_report/report/account_invoice_report_view.xml
@@ -42,6 +42,7 @@
         <field name="name">Invoice Lines</field>
         <field name="res_model">account.invoice.report</field>
         <field name="view_mode">list,pivot,graph</field>
+        <field name="search_view_id" />
         <field name="groups_id" eval="[(4, ref('account.group_account_user'))]" />
         <field
             name="help"


### PR DESCRIPTION
Coming from previous versions, the search view has a value, so we should make sure that in this one, it's emptied for not having incorrect behaviors.

@Tecnativa 