### PR TITLE
[FIX] account_invoice_production_lot: remove missing product_category_1 reference.

### DIFF
--- a/account_invoice_production_lot/demo/sale.xml
+++ b/account_invoice_production_lot/demo/sale.xml
@@ -7,7 +7,6 @@
     <record id="product_icecream_b" model="product.product">
         <field name="name">Ice Cream B</field>
         <field name="property_stock_inventory" ref="location_opening" />
-        <field name="categ_id" ref="product.product_category_1" />
         <field name="standard_price">70.0</field>
         <field name="list_price">100.0</field>
         <field name="type">consu</field>


### PR DESCRIPTION
In Odoo 19.0, the 'product.product_category_1' external ID has been removed in the base 'product' module data. This causes an error during the installation of the module or when loading test/demo records.

Since explicitly defining the 'categ_id' is not strictly required for this test record, this commit removes the field assignment entirely. The product will now use the standard default category, ensuring the module installs correctly without relying on deprecated data.