### PR TITLE
[18.0][IMP] account_invoice_report_grouped_by_picking: hides note and section lines.

### DIFF
--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -162,4 +162,11 @@ class AccountMove(models.Model):
             {"picking": key[0], "line": key[1], "quantity": value}
             for key, value in picking_dict.items()
         ]
-        return no_picking + self._sort_grouped_lines(with_picking + last_section_notes)
+        result = no_picking + self._sort_grouped_lines(
+            with_picking + last_section_notes
+        )
+        return [
+            lg
+            for lg in result
+            if lg["line"].display_type not in ("line_section", "line_note")
+        ]


### PR DESCRIPTION
For grouped by picking invoice report: hides note and section lines.