### PR TITLE
[18.0][ADD] account_invoice_report_untaxed_unrounded

### DIFF
--- a/account_invoice_report_untaxed_unrounded/__init__.py
+++ b/account_invoice_report_untaxed_unrounded/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_report_untaxed_unrounded/__manifest__.py
+++ b/account_invoice_report_untaxed_unrounded/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Quartile (https://www.quartile.co)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+{
+    "name": "Account Invoice Report Untaxed Unrounded",
+    "summary": "Show unrounded line subtotals in the invoice report when "
+    "currency rounding hides decimals",
+    "version": "18.0.1.0.0",
+    "category": "Account",
+    "website": "https://github.com/OCA/account-invoice-reporting",
+    "author": "Quartile, Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "development_status": "Alpha",
+    "application": False,
+    "installable": True,
+    "depends": ["account"],
+    "data": [
+        "views/report_invoice.xml",
+    ],
+}

--- a/account_invoice_report_untaxed_unrounded/models/__init__.py
+++ b/account_invoice_report_untaxed_unrounded/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_line

--- a/account_invoice_report_untaxed_unrounded/models/account_move_line.py
+++ b/account_invoice_report_untaxed_unrounded/models/account_move_line.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Quartile (https://www.quartile.co)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+from odoo import api, fields, models
+from odoo.tools import float_compare
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    price_subtotal_unrounded = fields.Float(
+        compute="_compute_price_subtotal_unrounded",
+        digits="Product Price",
+        help="Line subtotal computed without currency rounding. Used in reports "
+        "to disclose the decimals that the currency-rounded subtotal hides "
+        '(e.g. under "Round Globally" with a zero-decimal currency).',
+    )
+    is_price_subtotal_rounded = fields.Boolean(
+        compute="_compute_price_subtotal_unrounded",
+        help="True when the currency-rounded subtotal differs from the "
+        "unrounded one, i.e. rounding hides decimals.",
+    )
+
+    @api.depends("price_unit", "quantity", "discount", "price_subtotal")
+    def _compute_price_subtotal_unrounded(self):
+        precision = self.env["decimal.precision"].precision_get("Product Price")
+        for line in self:
+            unrounded = line.price_unit * line.quantity * (1 - line.discount / 100.0)
+            line.price_subtotal_unrounded = unrounded
+            line.is_price_subtotal_rounded = bool(
+                float_compare(
+                    unrounded, line.price_subtotal, precision_digits=precision
+                )
+            )

--- a/account_invoice_report_untaxed_unrounded/pyproject.toml
+++ b/account_invoice_report_untaxed_unrounded/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_invoice_report_untaxed_unrounded/readme/CONTRIBUTORS.md
+++ b/account_invoice_report_untaxed_unrounded/readme/CONTRIBUTORS.md
@@ -1,0 +1,2 @@
+- Quartile ([https://www.quartile.co](https://www.quartile.co)):
+  - Aung Ko Ko Lin

--- a/account_invoice_report_untaxed_unrounded/readme/DESCRIPTION.md
+++ b/account_invoice_report_untaxed_unrounded/readme/DESCRIPTION.md
@@ -1,0 +1,11 @@
+When an invoice uses **Round Globally** tax rounding with a zero-decimal
+currency (such as JPY), the per-line subtotal shown on the invoice report is
+rounded to the currency precision. The sum of these rounded line subtotals can
+then differ from the invoice untaxed total, which is computed on the unrounded
+amounts.
+
+This module discloses the hidden decimals: when a line's currency-rounded
+subtotal differs from its unrounded value, the invoice report shows the
+unrounded subtotal (with product-price decimal precision) instead of the
+rounded one. Lines without a rounding difference keep the standard
+currency-formatted presentation.

--- a/account_invoice_report_untaxed_unrounded/tests/__init__.py
+++ b/account_invoice_report_untaxed_unrounded/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_invoice_report_untaxed_unrounded

--- a/account_invoice_report_untaxed_unrounded/tests/test_account_invoice_report_untaxed_unrounded.py
+++ b/account_invoice_report_untaxed_unrounded/tests/test_account_invoice_report_untaxed_unrounded.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Quartile (https://www.quartile.co)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+from odoo.fields import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestUntaxedUnrounded(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env["res.company"].create(
+            {
+                "name": "test company",
+                "currency_id": cls.env.ref("base.JPY").id,
+                "tax_calculation_rounding_method": "round_globally",
+            }
+        )
+        cls.env.company = cls.company
+        cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
+        cls.product = cls.env["product.product"].create({"name": "Test Product"})
+        cls.account_income = cls.env["account.account"].create(
+            {"code": "test_inc", "name": "income", "account_type": "income"}
+        )
+        cls.tax_10 = cls.env["account.tax"].create(
+            {
+                "name": "Test Tax 10%",
+                "amount": 10.0,
+                "type_tax_use": "sale",
+                "company_id": cls.company.id,
+            }
+        )
+
+    def _create_invoice(self, price_unit):
+        invoice = (
+            self.env["account.move"]
+            .with_company(self.company)
+            .create(
+                {
+                    "move_type": "out_invoice",
+                    "partner_id": self.partner.id,
+                    "currency_id": self.company.currency_id.id,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "product_id": self.product.id,
+                                "account_id": self.account_income.id,
+                                "quantity": 1,
+                                "price_unit": price_unit,
+                                "tax_ids": [Command.set(self.tax_10.ids)],
+                            }
+                        )
+                    ],
+                }
+            )
+        )
+        invoice.action_post()
+        return invoice
+
+    def test_subtotal_rounded(self):
+        """A line whose subtotal loses decimals is flagged and exposes the
+        unrounded amount."""
+        invoice = self._create_invoice(100.3)
+        line = invoice.invoice_line_ids
+        # price_subtotal is rounded to JPY (zero decimals).
+        self.assertEqual(line.price_subtotal, 100)
+        self.assertTrue(line.is_price_subtotal_rounded)
+        self.assertAlmostEqual(line.price_subtotal_unrounded, 100.3, places=2)
+
+    def test_subtotal_not_rounded(self):
+        """A line with no rounding difference keeps the standard
+        presentation."""
+        invoice = self._create_invoice(100)
+        line = invoice.invoice_line_ids
+        self.assertEqual(line.price_subtotal, 100)
+        self.assertFalse(line.is_price_subtotal_rounded)
+        self.assertAlmostEqual(line.price_subtotal_unrounded, 100, places=2)

--- a/account_invoice_report_untaxed_unrounded/views/report_invoice.xml
+++ b/account_invoice_report_untaxed_unrounded/views/report_invoice.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 Quartile (https://www.quartile.co)
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0) -->
+<odoo>
+    <template
+        id="report_invoice_document"
+        inherit_id="account.report_invoice_document"
+    >
+        <xpath
+            expr="//td[@name='td_subtotal']/span[@t-field='line.price_subtotal']"
+            position="replace"
+        >
+            <span
+                class="text-nowrap"
+                t-if="not line.is_price_subtotal_rounded"
+                t-field="line.price_subtotal"
+            >27.00</span>
+            <span class="text-nowrap" t-else="">
+                <t t-if="o.currency_id.position == 'before'"><t
+                        t-out="o.currency_id.symbol"
+                    />&amp;nbsp;</t>
+                <t
+                    t-out="line.price_subtotal_unrounded"
+                    t-options='{"widget": "float", "decimal_precision": "Product Price"}'
+                />
+                <t
+                    t-if="o.currency_id.position == 'after'"
+                >&amp;nbsp;<t t-out="o.currency_id.symbol" /></t>
+            </span>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Module

`account_invoice_report_untaxed_unrounded`

When an invoice uses **Round Globally** tax rounding with a zero-decimal currency (such as JPY), each per-line subtotal shown on the invoice report is rounded to the currency precision. The sum of these rounded line subtotals can then differ from the invoice untaxed total (computed on the unrounded amounts).

This module discloses those hidden decimals: when a line's currency-rounded subtotal differs from its unrounded value, the invoice report shows the unrounded subtotal (with product-price decimal precision) instead of the rounded one. Lines without a rounding difference keep the standard currency-formatted presentation.
