### PR TITLE
[19.0][FIX] account_invoice_report_grouped_by_picking: convert grouped qty to invoice line UoM

### DIFF
--- a/account_invoice_report_grouped_by_picking/__manifest__.py
+++ b/account_invoice_report_grouped_by_picking/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Account Invoice Grouped by Picking",
     "summary": "Print invoice lines grouped by picking",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/account-invoice-reporting",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/account_invoice_report_grouped_by_picking/models/account_move.py
+++ b/account_invoice_report_grouped_by_picking/models/account_move.py
@@ -33,10 +33,20 @@ class AccountMove(models.Model):
         account_invoice_report_grouped_by_picking_sale_mrp module
         """
         if move.location_id.usage == "customer":
-            return -move.quantity * sign
-        if move.location_dest_id.usage == "customer":
-            return move.quantity * sign
-        return 0
+            qty = -move.quantity * sign
+        elif move.location_dest_id.usage == "customer":
+            qty = move.quantity * sign
+        else:
+            return 0
+        # move.quantity is in the move's (stock) UoM, but it is summed and
+        # subtracted against the invoice line quantity, which is in the invoice
+        # line UoM. Convert so both are in the same unit; otherwise the printed
+        # quantity is wrong and a bogus remainder line appears when they differ.
+        line_uom = invoice_line.product_uom_id
+        move_uom = move.product_uom
+        if qty and line_uom and move_uom and line_uom != move_uom:
+            qty = move_uom._compute_quantity(qty, line_uom, round=False)
+        return qty
 
     def _process_section_note_lines_grouped(
         self, previous_section, previous_note, lines_dic, pick_order=None

--- a/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
+++ b/account_invoice_report_grouped_by_picking/tests/test_account_invoice_group_picking.py
@@ -139,6 +139,61 @@ class TestAccountInvoiceGroupPicking(TransactionCase):
         self.assertTrue(self.sale.invoice_ids.picking_ids[:1].name in tbody)
         self.assertTrue(self.sale2.invoice_ids.picking_ids[:1].name in tbody)
 
+    def test_account_invoice_group_picking_uom_conversion(self):
+        """Grouped quantity is expressed in the invoice line UoM, not the stock
+        move UoM, and no bogus remainder line is produced when they differ."""
+        uom_unit = self.env.ref("uom.product_uom_unit")
+        uom_pack = self.env.ref("uom.product_uom_pack_6")
+        product_pack = self.env["product.product"].create(
+            {
+                "name": "Product sold per pack",
+                "invoice_policy": "delivery",
+                "uom_id": uom_unit.id,
+                "uom_ids": [(4, uom_unit.id), (4, uom_pack.id)],
+            }
+        )
+        sale = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product_pack.name,
+                            "product_id": product_pack.id,
+                            "product_uom_qty": 2,
+                            "product_uom_id": uom_pack.id,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+        sale.action_confirm()
+        # The delivery moves are in units (12), the invoice line is in packs (2).
+        picking = sale.picking_ids[:1]
+        picking.action_confirm()
+        picking.move_line_ids.write({"quantity": 12})
+        wiz_act = picking.button_validate()
+        if isinstance(wiz_act, dict) and wiz_act.get("res_model"):
+            wiz = Form(
+                self.env[wiz_act["res_model"]].with_context(**wiz_act["context"])
+            ).save()
+            wiz.process()
+        invoice = sale._create_invoices()
+        product_groups = [
+            group
+            for group in invoice.lines_grouped_by_picking()
+            if group["line"].product_id
+        ]
+        # Exactly one group (one delivery), no phantom remainder line.
+        self.assertEqual(len(product_groups), 1)
+        group = product_groups[0]
+        self.assertEqual(group["picking"], picking)
+        self.assertEqual(group["line"].product_uom_id, uom_pack)
+        self.assertAlmostEqual(group["quantity"], 2.0)
+
     def test_account_invoice_group_picking_return(self):
         self.sale.action_confirm()
         # deliver lines2


### PR DESCRIPTION
## Bug

`lines_grouped_by_picking` sums and subtracts the stock move quantity returned by `_get_signed_quantity_done` (expressed in the **move's UoM**, i.e. the product's stock UoM) against `line.quantity` / `remaining_qty` (expressed in the **invoice line UoM**), without converting between the two:

```python
remaining_qty = line.quantity            # invoice line UoM (e.g. 2 packs)
for move in line.move_line_ids:
    qty = self._get_signed_quantity_done(line, move, sign)  # move.quantity in stock UoM (e.g. 12 units)
    picking_dict[key] += qty             # printed in stock UoM
    remaining_qty -= qty                 # 2 - 12 = -10
...
if remaining_qty:                        # -10 is truthy
    lines_dict[line] = remaining_qty     # phantom remainder line
```

When the invoice line UoM differs from the product's stock UoM (e.g. selling in packs/pallets while stock is kept in units), two things go wrong:

1. The per-picking quantity is printed in the stock UoM instead of the invoice line UoM.
2. A bogus remainder line with a negative quantity is produced, because a stock-UoM quantity is subtracted from an invoice-line-UoM quantity.

It goes unnoticed in the common case where both UoMs are equal.

## Fix

`_get_signed_quantity_done` now converts the move quantity to the invoice line UoM before it is summed/subtracted. A regression test (`test_account_invoice_group_picking_uom_conversion`) covers a product sold per pack of 6 while delivered in units: exactly one group, expressed in packs, with no phantom remainder line.

## Test
`account_invoice_report_grouped_by_picking` test suite: 6/6 green.