### PR TITLE
[FIX][14.0] account_comment_template: fix the show the render of the …

### DIFF
--- a/account_comment_template/README.rst
+++ b/account_comment_template/README.rst
@@ -82,6 +82,10 @@ Contributors
 
   * Iván Todorovich <ivan.todorovich@druidoo.io>
 
+* `PT Solusi Aglis Indonesia <https://solusiaglis.co.id>`_:
+
+  * Panca Putra Pakpahan <ppakpahan@solusiaglis.co.id>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/account_comment_template/readme/CONTRIBUTORS.rst
+++ b/account_comment_template/readme/CONTRIBUTORS.rst
@@ -15,3 +15,7 @@
 * `Druidoo <https://www.druidoo.io>`_:
 
   * Iván Todorovich <ivan.todorovich@druidoo.io>
+
+* `PT Solusi Aglis Indonesia <https://solusiaglis.co.id>`_:
+
+  * Panca Putra Pakpahan <ppakpahan@solusiaglis.co.id>

--- a/account_comment_template/static/description/index.html
+++ b/account_comment_template/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -427,12 +427,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Iván Todorovich &lt;<a class="reference external" href="mailto:ivan.todorovich&#64;druidoo.io">ivan.todorovich&#64;druidoo.io</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://solusiaglis.co.id">PT Solusi Aglis Indonesia</a>:<ul>
+<li>Panca Putra Pakpahan &lt;<a class="reference external" href="mailto:ppakpahan&#64;solusiaglis.co.id">ppakpahan&#64;solusiaglis.co.id</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_comment_template/tests/test_account_move_report.py
+++ b/account_comment_template/tests/test_account_move_report.py
@@ -76,3 +76,26 @@ class TestAccountInvoiceReport(TransactionCase):
         new_invoice._compute_comment_template_ids()
         self.assertTrue(self.after_comment in new_invoice.comment_template_ids)
         self.assertTrue(self.before_comment in new_invoice.comment_template_ids)
+
+    def test_comment_expression_in_invoice_report(self):
+        """Placeholders must be evaluated, not printed verbatim."""
+        expression_comment = self.base_comment_model.create(
+            {
+                "name": "Comment with expression",
+                "company_id": self.company.id,
+                "position": "after_lines",
+                "text": "Customer: ${object.partner_id.name}",
+                "model_ids": [(6, 0, self.move_obj.ids)],
+            }
+        )
+        self.partner.base_comment_template_ids = [(4, expression_comment.id)]
+        self.invoice._compute_comment_template_ids()
+        self.assertIn(expression_comment, self.invoice.comment_template_ids)
+        res = (
+            self.env["ir.actions.report"]
+            ._get_report_from_name("account.report_invoice")
+            ._render_qweb_html(self.invoice.ids)
+        )
+        report = str(res[0])
+        self.assertIn("Customer: %s" % self.partner.name, report)
+        self.assertNotIn("${object.partner_id.name}", report)

--- a/account_comment_template/views/report_invoice.xml
+++ b/account_comment_template/views/report_invoice.xml
@@ -11,7 +11,7 @@
                 t-value="o.comment_template_ids.filtered(lambda x: x.position == 'before_lines')"
             />
             <t t-foreach="before_comment_template_ids" t-as="comment_template_id">
-                <div t-raw="comment_template_id.text" />
+                <div t-raw="o.render_comment(comment_template_id)" />
             </t>
         </xpath>
 
@@ -21,7 +21,7 @@
                 t-value="o.comment_template_ids.filtered(lambda x: x.position == 'after_lines')"
             />
             <t t-foreach="after_comment_template_ids" t-as="comment_template_id">
-                <div t-raw="comment_template_id.text" />
+                <div t-raw="o.render_comment(comment_template_id)" />
             </t>
         </xpath>
 


### PR DESCRIPTION
Placeholder expressions in the comment template were not being rendered correctly in the PDF report output. This PR fixes the rendering logic so expressions are properly evaluated and displayed.

Also added test cases to cover this scenario and prevent regression